### PR TITLE
Fixes the iOS capacitor status bar overlap

### DIFF
--- a/rogue-thi-app/.gitignore
+++ b/rogue-thi-app/.gitignore
@@ -40,3 +40,7 @@ yarn-error.log*
 
 # yarn ignore, they use npm ;/
 yarn.lock
+
+# capacitor
+/ios
+/android

--- a/rogue-thi-app/capacitor.config.json
+++ b/rogue-thi-app/capacitor.config.json
@@ -1,6 +1,6 @@
 {
   "appId": "app.neuland",
-  "appName": "Neuland App",
+  "appName": "neuland.app",
   "webDir": "out",
   "bundledWebRuntime": false
 }

--- a/rogue-thi-app/package.json
+++ b/rogue-thi-app/package.json
@@ -11,7 +11,9 @@
     "start": "next start",
     "android-add": "rm -rf android/ && npx cap add android",
     "android-open": "next build && next export && npx cap sync android && npx cap open android",
-    "android-run": "next build && next export && npx cap sync android && npx cap run android"
+    "android-run": "next build && next export && npx cap sync android && npx cap run android",
+    "ios-open": "next build && next export && npx cap sync ios && npx cap open ios",
+    "ios-run": "next build && next export && npx cap sync ios && npx cap run ios"
   },
   "dependencies": {
     "@capacitor-community/http": "^1.4.1",

--- a/rogue-thi-app/package.json
+++ b/rogue-thi-app/package.json
@@ -12,6 +12,7 @@
     "android-add": "rm -rf android/ && npx cap add android",
     "android-open": "next build && next export && npx cap sync android && npx cap open android",
     "android-run": "next build && next export && npx cap sync android && npx cap run android",
+    "ios-add": "rm -rf ios/ && npx cap add ios",
     "ios-open": "next build && next export && npx cap sync ios && npx cap open ios",
     "ios-run": "next build && next export && npx cap sync ios && npx cap run ios"
   },

--- a/rogue-thi-app/styles/AppNavbar.module.css
+++ b/rogue-thi-app/styles/AppNavbar.module.css
@@ -1,6 +1,7 @@
 .navbar {
   padding: 0 10px;
-  height: 50px;
+  padding-top: calc(env(safe-area-inset-top, 0px));
+  height: calc(50px + env(safe-area-inset-top, 0px));
   background-color: var(--navbar-background, white);
 }
 

--- a/rogue-thi-app/styles/AppNavbar.module.css
+++ b/rogue-thi-app/styles/AppNavbar.module.css
@@ -1,5 +1,6 @@
 .navbar {
   padding: 0 10px;
+  /* adds padding for the ios status bar to avoid the navbar overlapping the content */
   padding-top: calc(env(safe-area-inset-top, 0px));
   height: calc(50px + env(safe-area-inset-top, 0px));
   background-color: var(--navbar-background, white);

--- a/rogue-thi-app/styles/globals.css
+++ b/rogue-thi-app/styles/globals.css
@@ -26,7 +26,9 @@ body {
 /* prevent modals from being bigger than the screen */
 .modal-content {
   max-height: calc(90vh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
+  margin-top: env(safe-area-inset-top, 0px);
 }
+
 .modal-body {
   flex: unset;
   overflow-y: scroll;


### PR DESCRIPTION
- iOS specific paddings have been added to prevent the app from overlapping with the status bar.
  neuland-ingolstadt/neuland.app-ios#1
[neuland.app-ios](https://github.com/neuland-ingolstadt/neuland.app-ios)
- iOS specific paddings have been added to prevent modals from overlapping with the status bar.
- Three new scripts have been added to simplify the creation and opening of the iOS version.
- The gitignore was extended by the two android and iOS folders, since their builds are stored in separate repositories.
- The Capacitor App name has been changed to "neuland.app" according to the consultation with @alexhorn.