### PR TITLE
Updated calendar.json for winter and summer 22/23

### DIFF
--- a/rogue-thi-app/data/calendar.json
+++ b/rogue-thi-app/data/calendar.json
@@ -10,60 +10,136 @@
   },
   {
     "name": "Vorlesungsbeginn und Semesterstart",
-    "begin": "2022-03-15"
+    "begin": "2022-10-04"
   },
   {
-    "name": "Vorlesungsfrei (Ostern)",
-    "begin": "2022-04-14",
-    "end": "2022-04-19"
+    "name": "Vorlesungsfrei",
+    "begin": "2022-10-31"
   },
   {
     "name": "Prüfungsanmeldung",
-    "begin": "2022-05-02",
-    "end": "2022-05-12"
+    "begin": "2022-11-04",
+    "end": "2022-11-14"
   },
   {
     "name": "Prüfungsabmeldung",
-    "begin": "2022-05-02",
-    "end": "2022-06-24"
+    "begin": "2022-11-04",
+    "end": "2023-01-11"
   },
   {
-    "name": "Vorlesungsfrei (Christi Himmelfahrt, Brückentag)",
-    "begin": "2022-05-26",
-    "end": "2022-05-27"
+    "name": "Vorlesungsfrei (Weihnachten)",
+    "begin": "2022-12-24",
+    "end": "2023-01-08"
   },
   {
-    "name": "Vorlesungsfrei (Pfingsten)",
-    "begin": "2022-06-03",
-    "end": "2022-06-07"
-  },
-  {
-    "name": "Vorlesungsfrei (Fronleichnam)",
-    "begin": "2022-06-16"
-  },
-  {
-    "name": "Rückmeldung",
-    "begin": "2022-07-02",
-    "end": "2022-08-07"
+    "name": "Notenmeldung Prädikate (ZV)",
+    "begin": "2023-01-09T09:00",
+    "hasHours": true
   },
   {
     "name": "Erweiterter Prüfungszeitraum",
-    "begin": "2022-07-02",
-    "end": "2022-07-08"
+    "begin": "2023-01-19",
+    "end": "2023-01-25"
   },
   {
     "name": "Prüfungszeitraum",
-    "begin": "2022-07-09",
-    "end": "2022-07-19"
+    "begin": "2023-01-26",
+    "end": "2023-02-04"
+  },
+  {
+    "name": "Ende der Vorlesungszeit",
+    "begin": "2023-01-25"
+  },
+  {
+    "name": "Notenmeldung",
+    "begin": "2023-02-09T09:00",
+    "hasHours": true
   },
   {
     "name": "Notenbekanntgabe",
-    "begin": "2022-07-29T13:00",
+    "begin": "2023-02-14T13:00",
+    "hasHours": true
+  },
+  {
+    "name": "Rückmeldung zum Sommersemester 2023",
+    "begin": "2023-01-14",
+    "end": "2023-01-31"
+  },
+  {
+    "name": "Semesterferien",
+    "begin": "2022-02-15",
+    "end": "2022-03-14"
+  },
+  {
+    "name": "Vorlesungsbeginn und Semesterstart",
+    "begin": "2023-03-15"
+  },
+  {
+    "name": "Vorlesungsfrei (Ostern)",
+    "begin": "2023-04-06",
+    "end": "2023-04-11"
+  },
+  {
+    "name": "Prüfungsanmeldung",
+    "begin": "2023-04-25",
+    "end": "2023-05-04"
+  },
+  {
+    "name": "Prüfungsabmeldung",
+    "begin": "2023-04-25",
+    "end": "2023-06-26"
+  },
+  {
+    "name": "Vorlesungsfrei (Christi Himmelfahrt, Brückentag)",
+    "begin": "2023-05-18",
+    "end": "2023-05-19"
+  },
+  {
+    "name": "Vorlesungsfrei (Pfingsten)",
+    "begin": "2023-05-26",
+    "end": "2023-05-30"
+  },
+  {
+    "name": "Vorlesungsfrei (Fronleichnam)",
+    "begin": "2023-06-08"
+  },
+  {
+    "name": "Notenmeldung Prädikate (ZV)",
+    "begin": "2023-06-19T09:00",
+    "hasHours": true
+  },
+  {
+    "name": "Rückmeldung zum Wintersemester 2023/2024",
+    "begin": "2023-07-02",
+    "end": "2023-08-07"
+  },
+  {
+    "name": "Erweiterter Prüfungszeitraum",
+    "begin": "2023-07-04",
+    "end": "2023-07-07"
+  },
+  {
+    "name": "Prüfungszeitraum",
+    "begin": "2023-07-08",
+    "end": "2023-07-20"
+  },
+  {
+    "name": "Ende der Vorlesungszeit",
+    "begin": "2023-07-07"
+  },
+  {
+    "name": "Notenmeldung",
+    "begin": "2023-07-25T09:00",
+    "hasHours": true
+  },
+  {
+    "name": "Notenbekanntgabe",
+    "begin": "2023-07-31T13:00",
     "hasHours": true
   },
   {
     "name": "Semesterferien",
-    "begin": "2022-07-30",
-    "end": "2022-09-30"
+    "begin": "2023-08-01",
+    "end": "2023-09-30"
   }
 ]

--- a/rogue-thi-app/data/calendar.json
+++ b/rogue-thi-app/data/calendar.json
@@ -10,6 +10,64 @@
   },
   {
     "name": "Vorlesungsbeginn und Semesterstart",
+    "begin": "2022-03-15"
+  },
+  {
+    "name": "Vorlesungsfrei (Ostern)",
+    "begin": "2022-04-14",
+    "end": "2022-04-19"
+  },
+  {
+    "name": "Prüfungsanmeldung",
+    "begin": "2022-05-02",
+    "end": "2022-05-12"
+  },
+  {
+    "name": "Prüfungsabmeldung",
+    "begin": "2022-05-02",
+    "end": "2022-06-24"
+  },
+  {
+    "name": "Vorlesungsfrei (Christi Himmelfahrt, Brückentag)",
+    "begin": "2022-05-26",
+    "end": "2022-05-27"
+  },
+  {
+    "name": "Vorlesungsfrei (Pfingsten)",
+    "begin": "2022-06-03",
+    "end": "2022-06-07"
+  },
+  {
+    "name": "Vorlesungsfrei (Fronleichnam)",
+    "begin": "2022-06-16"
+  },
+  {
+    "name": "Rückmeldung",
+    "begin": "2022-07-02",
+    "end": "2022-08-07"
+  },
+  {
+    "name": "Erweiterter Prüfungszeitraum",
+    "begin": "2022-07-02",
+    "end": "2022-07-08"
+  },
+  {
+    "name": "Prüfungszeitraum",
+    "begin": "2022-07-09",
+    "end": "2022-07-19"
+  },
+  {
+    "name": "Notenbekanntgabe",
+    "begin": "2022-07-29T13:00",
+    "hasHours": true
+  },
+  {
+    "name": "Semesterferien",
+    "begin": "2022-07-30",
+    "end": "2022-09-30"
+  },
+  {
+    "name": "Vorlesungsbeginn und Semesterstart",
     "begin": "2022-10-04"
   },
   {


### PR DESCRIPTION
This includes an updated calendar.json for winter and summer semesters 2022 and 2023. 
The Names have been double checked as well as the times. 

@alexhorn you said you'll take a second look on it.