### PR TITLE
Added organizer links for Instagram and Website especially for Clubs at the THI

### DIFF
--- a/rogue-thi-app/data/calendar.json
+++ b/rogue-thi-app/data/calendar.json
@@ -10,60 +10,136 @@
   },
   {
     "name": "Vorlesungsbeginn und Semesterstart",
-    "begin": "2022-03-15"
+    "begin": "2022-10-04"
   },
   {
-    "name": "Vorlesungsfrei (Ostern)",
-    "begin": "2022-04-14",
-    "end": "2022-04-19"
+    "name": "Vorlesungsfrei",
+    "begin": "2022-10-31"
   },
   {
     "name": "Prüfungsanmeldung",
-    "begin": "2022-05-02",
-    "end": "2022-05-12"
+    "begin": "2022-11-04",
+    "end": "2022-11-14"
   },
   {
     "name": "Prüfungsabmeldung",
-    "begin": "2022-05-02",
-    "end": "2022-06-24"
+    "begin": "2022-11-04",
+    "end": "2023-01-11"
   },
   {
-    "name": "Vorlesungsfrei (Christi Himmelfahrt, Brückentag)",
-    "begin": "2022-05-26",
-    "end": "2022-05-27"
+    "name": "Vorlesungsfrei (Weihnachten)",
+    "begin": "2022-12-24",
+    "end": "2023-01-08"
   },
   {
-    "name": "Vorlesungsfrei (Pfingsten)",
-    "begin": "2022-06-03",
-    "end": "2022-06-07"
-  },
-  {
-    "name": "Vorlesungsfrei (Fronleichnam)",
-    "begin": "2022-06-16"
-  },
-  {
-    "name": "Rückmeldung",
-    "begin": "2022-07-02",
-    "end": "2022-08-07"
+    "name": "Notenmeldung Prädikate (ZV)",
+    "begin": "2023-01-09T09:00",
+    "hasHours": true
   },
   {
     "name": "Erweiterter Prüfungszeitraum",
-    "begin": "2022-07-02",
-    "end": "2022-07-08"
+    "begin": "2023-01-19",
+    "end": "2023-01-25"
   },
   {
     "name": "Prüfungszeitraum",
-    "begin": "2022-07-09",
-    "end": "2022-07-19"
+    "begin": "2023-01-26",
+    "end": "2023-02-04"
+  },
+  {
+    "name": "Ende der Vorlesungszeit",
+    "begin": "2023-01-25"
+  },
+  {
+    "name": "Notenmeldung",
+    "begin": "2023-02-09T09:00",
+    "hasHours": true
   },
   {
     "name": "Notenbekanntgabe",
-    "begin": "2022-07-29T13:00",
+    "begin": "2023-02-14T13:00",
+    "hasHours": true
+  },
+  {
+    "name": "Rückmeldung zum Sommersemester 2023",
+    "begin": "2023-01-14",
+    "end": "2023-01-31"
+  },
+  {
+    "name": "Semesterferien",
+    "begin": "2022-02-15",
+    "end": "2022-03-14"
+  },
+  {
+    "name": "Vorlesungsbeginn und Semesterstart",
+    "begin": "2023-03-15"
+  },
+  {
+    "name": "Vorlesungsfrei (Ostern)",
+    "begin": "2023-04-06",
+    "end": "2023-04-11"
+  },
+  {
+    "name": "Prüfungsanmeldung",
+    "begin": "2023-04-25",
+    "end": "2023-05-04"
+  },
+  {
+    "name": "Prüfungsabmeldung",
+    "begin": "2023-04-25",
+    "end": "2023-06-26"
+  },
+  {
+    "name": "Vorlesungsfrei (Christi Himmelfahrt, Brückentag)",
+    "begin": "2023-05-18",
+    "end": "2023-05-19"
+  },
+  {
+    "name": "Vorlesungsfrei (Pfingsten)",
+    "begin": "2023-05-26",
+    "end": "2023-05-30"
+  },
+  {
+    "name": "Vorlesungsfrei (Fronleichnam)",
+    "begin": "2023-06-08"
+  },
+  {
+    "name": "Notenmeldung Prädikate (ZV)",
+    "begin": "2023-06-19T09:00",
+    "hasHours": true
+  },
+  {
+    "name": "Rückmeldung zum Wintersemester 2023/2024",
+    "begin": "2023-07-02",
+    "end": "2023-08-07"
+  },
+  {
+    "name": "Erweiterter Prüfungszeitraum",
+    "begin": "2023-07-04",
+    "end": "2023-07-07"
+  },
+  {
+    "name": "Prüfungszeitraum",
+    "begin": "2023-07-08",
+    "end": "2023-07-20"
+  },
+  {
+    "name": "Ende der Vorlesungszeit",
+    "begin": "2023-07-07"
+  },
+  {
+    "name": "Notenmeldung",
+    "begin": "2023-07-25T09:00",
+    "hasHours": true
+  },
+  {
+    "name": "Notenbekanntgabe",
+    "begin": "2023-07-31T13:00",
     "hasHours": true
   },
   {
     "name": "Semesterferien",
-    "begin": "2022-07-30",
-    "end": "2022-09-30"
+    "begin": "2023-08-01",
+    "end": "2023-09-30"
   }
 ]

--- a/rogue-thi-app/data/calendar.json
+++ b/rogue-thi-app/data/calendar.json
@@ -10,6 +10,64 @@
   },
   {
     "name": "Vorlesungsbeginn und Semesterstart",
+    "begin": "2022-03-15"
+  },
+  {
+    "name": "Vorlesungsfrei (Ostern)",
+    "begin": "2022-04-14",
+    "end": "2022-04-19"
+  },
+  {
+    "name": "Prüfungsanmeldung",
+    "begin": "2022-05-02",
+    "end": "2022-05-12"
+  },
+  {
+    "name": "Prüfungsabmeldung",
+    "begin": "2022-05-02",
+    "end": "2022-06-24"
+  },
+  {
+    "name": "Vorlesungsfrei (Christi Himmelfahrt, Brückentag)",
+    "begin": "2022-05-26",
+    "end": "2022-05-27"
+  },
+  {
+    "name": "Vorlesungsfrei (Pfingsten)",
+    "begin": "2022-06-03",
+    "end": "2022-06-07"
+  },
+  {
+    "name": "Vorlesungsfrei (Fronleichnam)",
+    "begin": "2022-06-16"
+  },
+  {
+    "name": "Rückmeldung",
+    "begin": "2022-07-02",
+    "end": "2022-08-07"
+  },
+  {
+    "name": "Erweiterter Prüfungszeitraum",
+    "begin": "2022-07-02",
+    "end": "2022-07-08"
+  },
+  {
+    "name": "Prüfungszeitraum",
+    "begin": "2022-07-09",
+    "end": "2022-07-19"
+  },
+  {
+    "name": "Notenbekanntgabe",
+    "begin": "2022-07-29T13:00",
+    "hasHours": true
+  },
+  {
+    "name": "Semesterferien",
+    "begin": "2022-07-30",
+    "end": "2022-09-30"
+  },
+  {
+    "name": "Vorlesungsbeginn und Semesterstart",
     "begin": "2022-10-04"
   },
   {

--- a/rogue-thi-app/data/clubs.json
+++ b/rogue-thi-app/data/clubs.json
@@ -27,16 +27,16 @@
   {
     "club": "Our Future e. V.",
     "instagram": "https://www.instagram.com/ourfuture_ingolstadt/",
-    "website": "https://www.ourfuturethi.de/Ne"
+    "website": "https://www.ourfuturethi.de/"
   },
   {
     "club": "NEWEXIST e. V.",
-    "instagram": "",
+    "instagram": "https://www.instagram.com/newexist_official/",
     "website": "https://newexist.com/"
   },
   {
     "club": "N.I.C.E. e. V.",
-    "instagram": "https://www.instagram.com/newexist_official/",
+    "instagram": "https://www.instagram.com/niceingolstadt/",
     "website": "https://www.thi.de/studium/studentisches-leben/studentische-vereine-an-der-thi/nice-network-international-culture-exchange/"
   },
   {
@@ -67,7 +67,7 @@
   {
     "club": "Hochschulgaming Ingolstadt",
     "instagram": "https://www.instagram.com/hochschulgaming_in/",
-    "website": "https://discord.gg/C67R2yXjJd"
+    "website": "https://hochschulgaming.de/"
   },
   {
     "club": "LEO Club Ingolstadt",

--- a/rogue-thi-app/data/clubs.json
+++ b/rogue-thi-app/data/clubs.json
@@ -1,0 +1,82 @@
+[
+  {
+    "club": "Studierendenvertretung",
+    "instagram": "https://www.instagram.com/studverthi/",
+    "website": "https://studverthi.de"
+  },
+  {
+    "club": "Hochschulband",
+    "instagram": "https://www.instagram.com/studverthi/",
+    "website": "https://studverthi.de"
+  },
+  {
+    "club": "Hochschulkino",
+    "instagram": "https://www.instagram.com/hochschulkino.thi/",
+    "website": "https://studverthi.de/hochschulkino"
+  },
+  {
+    "club": "think e. V.",
+    "instagram": "https://www.instagram.com/think.thi/",
+    "website": "https://think-thi.de/"
+  },
+  {
+    "club": "Neuland Ingolstadt e. V.",
+    "instagram": "https://www.instagram.com/neuland_ingolstadt/",
+    "website": "https://neuland-ingolstadt.de/"
+  },
+  {
+    "club": "Our Future e. V.",
+    "instagram": "https://www.instagram.com/ourfuture_ingolstadt/",
+    "website": "https://www.ourfuturethi.de/Ne"
+  },
+  {
+    "club": "NEWEXIST e. V.",
+    "instagram": "",
+    "website": "https://newexist.com/"
+  },
+  {
+    "club": "N.I.C.E. e. V.",
+    "instagram": "https://www.instagram.com/newexist_official/",
+    "website": "https://www.thi.de/studium/studentisches-leben/studentische-vereine-an-der-thi/nice-network-international-culture-exchange/"
+  },
+  {
+    "club": "Eta-nol e. V.",
+    "instagram": "https://www.instagram.com/eta_nol_in/",
+    "website": "https://eta-nol.de/"
+  },
+  {
+    "club": "Students' Life e.V.",
+    "instagram": "https://www.instagram.com/studentslife.thingolstadt/",
+    "website": "https://students-life.de"
+  },
+  {
+    "club": "consult.IN e.V.",
+    "instagram": "https://www.instagram.com/consult.in/",
+    "website": "https://consultin.net/"
+  },
+  {
+    "club": "Schanzer Racing Electric e.V.",
+    "instagram": "https://www.instagram.com/schanzerracing/",
+    "website": "https://www.schanzer-racing.de/"
+  },
+  {
+    "club": "UNICEF Hochschulgruppe",
+    "instagram": "https://www.instagram.com/unicef_hsg_in/",
+    "website": "https://www.unicef.de/mitmachen/ehrenamtlich-aktiv/-/hochschulgruppe-thi-ingolstadt"
+  },
+  {
+    "club": "Hochschulgaming Ingolstadt",
+    "instagram": "https://www.instagram.com/hochschulgaming_in/",
+    "website": "https://discord.gg/C67R2yXjJd"
+  },
+  {
+    "club": "LEO Club Ingolstadt",
+    "instagram": "https://www.instagram.com/leoclubingolstadt/",
+    "website": "https://www.thi.de/studium/studentisches-leben/studentische-vereine-an-der-thi/leo-club-ingolstadt/"
+  },
+  {
+    "club": "Studentischer Börsenclub Ingolstadt e. V.",
+    "instagram": "https://www.instagram.com/boersenclubingolstadt/",
+    "website": "https://www.boersenclub-ingolstadt.de/"
+  }
+]

--- a/rogue-thi-app/data/clubs.json
+++ b/rogue-thi-app/data/clubs.json
@@ -1,16 +1,16 @@
 [
   {
-    "club": "Studierendenvertretung",
+    "club": "Studierendenvertretung .",
     "instagram": "https://www.instagram.com/studverthi/",
     "website": "https://studverthi.de"
   },
   {
-    "club": "Hochschulband",
+    "club": "Hochschulband .",
     "instagram": "https://www.instagram.com/studverthi/",
     "website": "https://studverthi.de"
   },
   {
-    "club": "Hochschulkino",
+    "club": "Hochschulkino .",
     "instagram": "https://www.instagram.com/hochschulkino.thi/",
     "website": "https://studverthi.de/hochschulkino"
   },

--- a/rogue-thi-app/pages/calendar.js
+++ b/rogue-thi-app/pages/calendar.js
@@ -180,9 +180,9 @@ export default function Calendar () {
             <ListGroup variant="flush">
               <ReactPlaceholder type="text" rows={10} ready={events}>
                 {events && events.length === 0 && (
-                    <ListGroup.Item className={styles.item}>
-                      Es sind derzeit keine Veranstaltungstermine verfügbar.
-                    </ListGroup.Item>
+                  <ListGroup.Item className={styles.item}>
+                    Es sind derzeit keine Veranstaltungstermine verfügbar.
+                  </ListGroup.Item>
                 )}
                 {events && events.map((item, idx) => {
                   const club = clubs.find(club => club.club === item.organizer)
@@ -199,14 +199,18 @@ export default function Calendar () {
                           <div className={styles.details}>
                         <span>
                           { club != null &&
-                              <>
+                            <>
+                              {club.website != null &&
                                 <a href={club.website} className={styles.eventUrl} target="_blank" rel="noreferrer">
                                   {item.organizer}<FontAwesomeIcon icon={faExternalLink} fixedWidth/>
                                 </a>
+                              }
+                              {club.instagram != null &&
                                 <a href={club.instagram} className={styles.eventUrl} target="_blank" rel="noreferrer">
                                   <FontAwesomeIcon icon={faInstagram} fixedWidth/>
                                 </a>
-                              </>
+                              }
+                            </>
                           }
                           { club == null &&
                               <>

--- a/rogue-thi-app/pages/calendar.js
+++ b/rogue-thi-app/pages/calendar.js
@@ -7,7 +7,7 @@ import Modal from 'react-bootstrap/Modal'
 import ReactPlaceholder from 'react-placeholder'
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons'
+import { faExternalLink, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons'
 
 import SwipeableTabs, { SwipeableTab } from '../components/SwipeableTabs'
 import AppBody from '../components/page/AppBody'
@@ -25,8 +25,10 @@ import {
 import NeulandAPI from '../lib/backend/neuland-api'
 import { NoSessionError } from '../lib/backend/thi-session-handler'
 import { useTime } from '../lib/hooks/time-hook'
+import clubs from '../data/clubs.json'
 
 import styles from '../styles/Calendar.module.css'
+import { faInstagram } from '@fortawesome/free-brands-svg-icons'
 
 export default function Calendar () {
   const router = useRouter()
@@ -178,25 +180,43 @@ export default function Calendar () {
             <ListGroup variant="flush">
               <ReactPlaceholder type="text" rows={10} ready={events}>
                 {events && events.length === 0 && (
-                  <ListGroup.Item className={styles.item}>
-                    Es sind derzeit keine Veranstaltungstermine verfügbar.
-                  </ListGroup.Item>
+                    <ListGroup.Item className={styles.item}>
+                      Es sind derzeit keine Veranstaltungstermine verfügbar.
+                    </ListGroup.Item>
                 )}
-                {events && events.map((item, idx) =>
-                  <ListGroup.Item key={idx} className={styles.item}>
-                    <div className={styles.left}>
-                      {!item.url && item.title}
-                      {item.url && (
-                        <a href={item.url} className={styles.eventUrl} target="_blank" rel="noreferrer">
-                          {item.title}
-                          {' '}
-                          <FontAwesomeIcon icon={faExternalLinkAlt} />
-                        </a>
-                      )}
-                      <div className={styles.details}>
-                        {item.organizer} <br />
-                        {item.begin && formatFriendlyDateTimeRange(item.begin, item.end)}
-                      </div>
+                {events && events.map((item, idx) => {
+                  const club = clubs.find(club => club.club === item.organizer)
+                  return <ListGroup.Item key={idx} className={styles.item}>
+                        <div className={styles.left}>
+                          {!item.url && item.title}
+                          {item.url && (
+                              <a href={item.url} className={styles.eventUrl} target="_blank" rel="noreferrer">
+                                {item.title}
+                                {' '}
+                                <FontAwesomeIcon icon={faExternalLinkAlt}/>
+                              </a>
+                          )}
+                          <div className={styles.details}>
+                        <span>
+                          { club != null &&
+                              <>
+                                <a href={club.website} className={styles.eventUrl} target="_blank" rel="noreferrer">
+                                  {item.organizer}<FontAwesomeIcon icon={faExternalLink} fixedWidth/>
+                                </a>
+                                <a href={club.instagram} className={styles.eventUrl} target="_blank" rel="noreferrer">
+                                  <FontAwesomeIcon icon={faInstagram} fixedWidth/>
+                                </a>
+                              </>
+                          }
+                          { club == null &&
+                              <>
+                                {item.organizer}
+                              </>
+                          }
+                        </span>
+                            <br/>
+                            {item.begin && formatFriendlyDateTimeRange(item.begin, item.end)}
+                          </div>
 
                     </div>
                     <div className={styles.details}>
@@ -205,6 +225,7 @@ export default function Calendar () {
                         : formatFriendlyRelativeTime(item.begin)}
                     </div>
                   </ListGroup.Item>
+                }
                 )}
               </ReactPlaceholder>
             </ListGroup>


### PR DESCRIPTION
Due to the fact, that we do not scrape the descriptions of a event. I thought it might be useful to include at least the social media/website of the clubs. 

This the same as in the rework of ophase I'm currently working on.