### PR TITLE
Fix the text overflow in the mobility card in retro themes

### DIFF
--- a/rogue-thi-app/lib/backend-utils/mobility-utils.js
+++ b/rogue-thi-app/lib/backend-utils/mobility-utils.js
@@ -120,7 +120,7 @@ export function renderMobilityEntry (kind, item, maxLen, styles) {
           {item.route}
         </div>
         <div className={styles.mobilityDestination}>
-          {item.destination.length <= maxLen ? item.destination : item.destination.substr(0, maxLen) + '…'}
+          {item.destination}
         </div>
         <div className={styles.mobilityTime}>
           {formatRelativeMinutes(new Date(item.time))}

--- a/rogue-thi-app/styles/Home.module.css
+++ b/rogue-thi-app/styles/Home.module.css
@@ -71,12 +71,14 @@
 .mobilityItem {
   padding: .25rem;
   border: 0;
+  display: flex;
 }
 
 .mobilityRoute {
   padding: 0px 3px;
   margin-right: 6px;
   min-width: 2.5em;
+  white-space: nowrap;
   text-align: center;
   float: left;
   background: #eeeeee;
@@ -86,13 +88,13 @@
 }
 
 .mobilityDestination {
-  width: 100%;
+  flex: 1;
   white-space: nowrap;
-  float: left;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .mobilityTime {
-  float: right;
+  white-space: nowrap;
+  width: auto;
 }

--- a/rogue-thi-app/styles/Home.module.css
+++ b/rogue-thi-app/styles/Home.module.css
@@ -86,7 +86,11 @@
 }
 
 .mobilityDestination {
+  width: 100%;
+  white-space: nowrap;
   float: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .mobilityTime {

--- a/rogue-thi-app/styles/Mobility.module.css
+++ b/rogue-thi-app/styles/Mobility.module.css
@@ -31,6 +31,9 @@
 
 .mobilityDestination {
   flex: 1;
+  white-space: break-spaces;
+  word-break: break-word;
+  margin-right: 5px;
 }
 
 .mobilityTime {


### PR DESCRIPTION
This removes the programmatic truncating of the strings and instead uses css rules to just show "..." if the string is to long. This should work with any string and any theme
I'm only aware of the overflow happening in the mobility card but if it happens anywhere else, these css rules should be applicable

This fixes #177 