### PR TITLE
Show average in personal.js instead of [object Object]

### DIFF
--- a/rogue-thi-app/pages/personal.js
+++ b/rogue-thi-app/pages/personal.js
@@ -166,8 +166,8 @@ export default function Personal () {
                 {ects !== null && ects + ' ECTS'}
                 {average && ' · '}
                 {average && '∅ ' + average.result}
-                {average && 'missingWeight' in average && average.missingWeight === 1 && ' (' + average.missingWeight + ' Gewichtung fehlt)'}
-                {average && 'missingWeight' in average && average.missingWeight > 0 && ' (' + average.missingWeight + ' Gewichtungen fehlen)'}
+                {average && average?.missingWeight === 1 && ' (' + average.missingWeight + ' Gewichtung fehlt)'}
+                {average && average?.missingWeight > 1 && ' (' + average.missingWeight + ' Gewichtungen fehlen)'}
               </span>
             </ListGroup.Item>
           </ListGroup>

--- a/rogue-thi-app/pages/personal.js
+++ b/rogue-thi-app/pages/personal.js
@@ -165,7 +165,6 @@ export default function Personal () {
               <span className="text-muted">
                 {ects !== null && ects + ' ECTS'}
                 {average && ' · '}
-                {average && '∅ ' + average}
                 {average && '∅ ' + average.result}
                 {average && 'missingWeight' in average && average.missingWeight === 1 && ' (' + average.missingWeight + ' Gewichtung fehlt)'}
                 {average && 'missingWeight' in average && average.missingWeight > 0 && ' (' + average.missingWeight + ' Gewichtungen fehlen)'}

--- a/rogue-thi-app/pages/personal.js
+++ b/rogue-thi-app/pages/personal.js
@@ -166,6 +166,9 @@ export default function Personal () {
                 {ects !== null && ects + ' ECTS'}
                 {average && ' · '}
                 {average && '∅ ' + average}
+                {average && '∅ ' + average.result}
+                {average && 'missingWeight' in average && average.missingWeight === 1 && ' (' + average.missingWeight + ' Gewichtung fehlt)'}
+                {average && 'missingWeight' in average && average.missingWeight > 0 && ' (' + average.missingWeight + ' Gewichtungen fehlen)'}
               </span>
             </ListGroup.Item>
           </ListGroup>


### PR DESCRIPTION
Fixes #199 and shows the average grade (and the missing weights) instead of [object Object]

(Pretty new to JS and this project, I hope it's correct)