### PR TITLE
🥗 Swipe-able weekly food tabs

### DIFF
--- a/rogue-thi-app/components/SwipeableTabs.js
+++ b/rogue-thi-app/components/SwipeableTabs.js
@@ -9,14 +9,21 @@ import SwipeableViews from 'react-swipeable-views'
  * @param {string} className Class name to attach to the entire object
  * @param {object} children Array of `SwipeableTab` objects
  */
-export default function SwipeableTabs ({ className, children }) {
+export default function SwipeableTabs ({ className, children, fillers }) {
   const [page, setPage] = useState(0)
 
   return (
     <div className={className}>
       <Nav variant="pills" activeKey={page.toString()} onSelect={key => setPage(parseInt(key))}>
+        {fillers && fillers.map((child, idx) =>
+          <Nav.Item key={idx} >
+            <Nav.Link className='disabled'>
+              {child.title}
+            </Nav.Link>
+          </Nav.Item>
+        )}
         {children.map((child, idx) =>
-          <Nav.Item key={idx}>
+          <Nav.Item key={idx + (fillers?.length ?? 0)}>
             <Nav.Link eventKey={idx.toString()}>
               {child.props.title}
             </Nav.Link>
@@ -31,7 +38,8 @@ export default function SwipeableTabs ({ className, children }) {
 }
 SwipeableTabs.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.any
+  children: PropTypes.any,
+  fillers: PropTypes.any
 }
 
 /**
@@ -47,6 +55,6 @@ export function SwipeableTab ({ className, children }) {
 }
 SwipeableTab.propTypes = {
   className: PropTypes.string,
-  title: PropTypes.string,
+  title: PropTypes.object,
   children: PropTypes.any
 }

--- a/rogue-thi-app/lib/backend-utils/food-utils.js
+++ b/rogue-thi-app/lib/backend-utils/food-utils.js
@@ -8,6 +8,8 @@ import { formatISODate } from '../date-utils'
  */
 export async function loadFoodEntries (restaurants) {
   const entries = []
+  return entries
+
   if (restaurants.includes('mensa')) {
     const data = await NeulandAPI.getMensaPlan()
     data.forEach(day => day.meals.forEach(entry => {

--- a/rogue-thi-app/lib/backend-utils/food-utils.js
+++ b/rogue-thi-app/lib/backend-utils/food-utils.js
@@ -8,7 +8,6 @@ import { formatISODate } from '../date-utils'
  */
 export async function loadFoodEntries (restaurants) {
   const entries = []
-  return entries
 
   if (restaurants.includes('mensa')) {
     const data = await NeulandAPI.getMensaPlan()

--- a/rogue-thi-app/lib/date-utils.js
+++ b/rogue-thi-app/lib/date-utils.js
@@ -1,8 +1,8 @@
 
 const WORD_TODAY = 'Heute'
 const WORD_TOMORROW = 'Morgen'
-const WORD_THIS_WEEK = 'Diese Woche'
-const WORD_NEXT_WEEK = 'Nächste Woche'
+export const WORD_THIS_WEEK = 'Diese Woche'
+export const WORD_NEXT_WEEK = 'Nächste Woche'
 
 export const DATE_LOCALE = 'de-DE'
 

--- a/rogue-thi-app/pages/food.js
+++ b/rogue-thi-app/pages/food.js
@@ -44,15 +44,20 @@ export default function Mensa () {
     allergenSelection,
     setShowFoodFilterModal
   } = useContext(FoodFilterContext)
-  const [foodDays, setFoodDays] = useState(null)
+  const [currentFoodDays, setCurrentFoodDays] = useState(null)
+  const [futureFoodDays, setFutureFoodDays] = useState(null)
   const [showMealDetails, setShowMealDetails] = useState(null)
   const userKind = useUserKind()
 
   useEffect(() => {
     async function load () {
       try {
+        const daysTillFriday = 5 - new Date().getDay() + 1
+
         const days = await loadFoodEntries(selectedRestaurants)
-        setFoodDays(days.slice(0, 5))
+
+        setCurrentFoodDays(days.slice(0, daysTillFriday))
+        setFutureFoodDays(days.slice(daysTillFriday, days.length))
       } catch (e) {
         console.error(e)
         alert(e)
@@ -218,10 +223,21 @@ export default function Mensa () {
       </AppNavbar>
 
       <AppBody>
-        <ReactPlaceholder type="text" rows={20} ready={foodDays}>
+        <ReactPlaceholder type="text" rows={20} ready={currentFoodDays && futureFoodDays}>
           <SwipeableTabs className={styles.tab}>
-            {foodDays && foodDays.map((day, idx) => renderMealDay(day, idx))}
+            <SwipeableTab title="Aktuelle Woche">
+              <SwipeableTabs className={styles.tab}>
+                {currentFoodDays && currentFoodDays.map((day, idx) => renderMealDay(day, idx))}
+              </SwipeableTabs>
+            </SwipeableTab>
+
+            <SwipeableTab title="Nächste Woche">
+              <SwipeableTabs className={styles.tab}>
+                {futureFoodDays && futureFoodDays.map((day, idx) => renderMealDay(day, idx))}
+              </SwipeableTabs>
+            </SwipeableTab>
           </SwipeableTabs>
+
         </ReactPlaceholder>
 
         <br/>

--- a/rogue-thi-app/pages/food.js
+++ b/rogue-thi-app/pages/food.js
@@ -222,6 +222,12 @@ export default function Mensa () {
     )
   }
 
+  const dayFiller = Array.from({ length: 5 - currentFoodDays?.length }, (_, i) => i).map((x, idx) => {
+    const day = new Date()
+    day.setDate(day.getDate() + idx)
+    return { title: buildLinedWeekdaySpan(day), key: idx }
+  })
+
   return (
     <AppContainer>
       <AppNavbar title="Essen" showBack={'desktop-only'}>
@@ -246,7 +252,7 @@ export default function Mensa () {
 
         <ReactPlaceholder type="text" rows={20} ready={currentFoodDays && futureFoodDays}>
           <SwipeableViews index={page} onChangeIndex={idx => setPage(idx)}>
-            <SwipeableTabs className={styles.tab}>
+            <SwipeableTabs className={styles.tab} fillers={dayFiller}>
               {currentFoodDays && currentFoodDays.map((day, idx) => renderMealDay(day, idx))}
             </SwipeableTabs>
 

--- a/rogue-thi-app/pages/food.js
+++ b/rogue-thi-app/pages/food.js
@@ -62,10 +62,10 @@ export default function Mensa () {
          * api returns full next 2 weeks on weekends, so just `new Date()`
          * to calculate the days till friday would be wrong (higher than 5)
          * */
-        const daysTillFriday = 5 - new Date(days[0].timestamp).getDay() + 1
+        const daysTillFriday = days?.length > 0 ? (5 - new Date(days[0].timestamp).getDay() + 1) : 0
 
         setCurrentFoodDays(days.slice(0, daysTillFriday))
-        setFutureFoodDays(days.slice(daysTillFriday, days.length))
+        setFutureFoodDays(days?.slice(daysTillFriday, days.length))
       } catch (e) {
         console.error(e)
         alert(e)
@@ -245,7 +245,7 @@ export default function Mensa () {
             {page === 0 && WORD_THIS_WEEK}
             {page === 1 && WORD_NEXT_WEEK}
           </div>
-          <Button className={styles.nextWeek} variant="link" onClick={() => setPage(1)} disabled={page === 1}>
+          <Button className={styles.nextWeek} variant="link" onClick={() => setPage(1)} disabled={page === 1 || futureFoodDays?.length === 0}>
             <FontAwesomeIcon title="Woche vor" icon={faChevronRight} />
           </Button>
         </div>

--- a/rogue-thi-app/pages/food.js
+++ b/rogue-thi-app/pages/food.js
@@ -5,7 +5,7 @@ import ListGroup from 'react-bootstrap/ListGroup'
 import Modal from 'react-bootstrap/Modal'
 import ReactPlaceholder from 'react-placeholder'
 
-import { faExclamationTriangle, faFilter, faThumbsUp } from '@fortawesome/free-solid-svg-icons'
+import { faChevronLeft, faChevronRight, faExclamationTriangle, faFilter, faThumbsUp } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
 import AppBody from '../components/page/AppBody'
@@ -14,15 +14,17 @@ import AppNavbar from '../components/page/AppNavbar'
 import AppTabbar from '../components/page/AppTabbar'
 
 import { USER_EMPLOYEE, USER_GUEST, USER_STUDENT, useUserKind } from '../lib/hooks/user-kind'
+import { WORD_NEXT_WEEK, WORD_THIS_WEEK, buildLinedWeekdaySpan } from '../lib/date-utils'
 import FilterFoodModal from '../components/modal/FilterFoodModal'
 import { FoodFilterContext } from './_app'
-import { buildLinedWeekdaySpan } from '../lib/date-utils'
 import { loadFoodEntries } from '../lib/backend-utils/food-utils'
 
 import SwipeableTabs, { SwipeableTab } from '../components/SwipeableTabs'
 import allergenMap from '../data/allergens.json'
 import flagMap from '../data/mensa-flags.json'
 import styles from '../styles/Mensa.module.css'
+
+import SwipeableViews from 'react-swipeable-views'
 
 const CURRENCY_LOCALE = 'de'
 const COLOR_WARN = '#bb0000'
@@ -47,14 +49,20 @@ export default function Mensa () {
   const [currentFoodDays, setCurrentFoodDays] = useState(null)
   const [futureFoodDays, setFutureFoodDays] = useState(null)
   const [showMealDetails, setShowMealDetails] = useState(null)
+  const [page, setPage] = useState(0)
   const userKind = useUserKind()
 
   useEffect(() => {
     async function load () {
       try {
-        const daysTillFriday = 5 - new Date().getDay() + 1
-
         const days = await loadFoodEntries(selectedRestaurants)
+
+        /**
+         * new Date(days[0].timestamp).getDay()
+         * api returns full next 2 weeks on weekends, so just `new Date()`
+         * to calculate the days till friday would be wrong (higher than 5)
+         * */
+        const daysTillFriday = 5 - new Date(days[0].timestamp).getDay() + 1
 
         setCurrentFoodDays(days.slice(0, daysTillFriday))
         setFutureFoodDays(days.slice(daysTillFriday, days.length))
@@ -223,21 +231,29 @@ export default function Mensa () {
       </AppNavbar>
 
       <AppBody>
+        <div className={styles.weekSelector}>
+          <Button className={styles.prevWeek} variant="link" onClick={() => setPage(0)} disabled={page === 0}>
+            <FontAwesomeIcon title="Woche zurück" icon={faChevronLeft} />
+          </Button>
+          <div className={styles.currentWeek}>
+            {page === 0 && WORD_THIS_WEEK}
+            {page === 1 && WORD_NEXT_WEEK}
+          </div>
+          <Button className={styles.nextWeek} variant="link" onClick={() => setPage(1)} disabled={page === 1}>
+            <FontAwesomeIcon title="Woche vor" icon={faChevronRight} />
+          </Button>
+        </div>
+
         <ReactPlaceholder type="text" rows={20} ready={currentFoodDays && futureFoodDays}>
-          <SwipeableTabs className={styles.tab}>
-            <SwipeableTab title="Aktuelle Woche">
-              <SwipeableTabs className={styles.tab}>
-                {currentFoodDays && currentFoodDays.map((day, idx) => renderMealDay(day, idx))}
-              </SwipeableTabs>
-            </SwipeableTab>
+          <SwipeableViews index={page} onChangeIndex={idx => setPage(idx)}>
+            <SwipeableTabs className={styles.tab}>
+              {currentFoodDays && currentFoodDays.map((day, idx) => renderMealDay(day, idx))}
+            </SwipeableTabs>
 
-            <SwipeableTab title="Nächste Woche">
-              <SwipeableTabs className={styles.tab}>
-                {futureFoodDays && futureFoodDays.map((day, idx) => renderMealDay(day, idx))}
-              </SwipeableTabs>
-            </SwipeableTab>
-          </SwipeableTabs>
-
+            <SwipeableTabs className={styles.tab}>
+              {futureFoodDays && futureFoodDays.map((day, idx) => renderMealDay(day, idx))}
+            </SwipeableTabs>
+          </SwipeableViews>
         </ReactPlaceholder>
 
         <br/>

--- a/rogue-thi-app/styles/Mensa.module.css
+++ b/rogue-thi-app/styles/Mensa.module.css
@@ -33,3 +33,14 @@
   font-size: .8rem;
   color: gray;
 }
+
+/* week selector */
+.weekSelector {
+  display: flex;
+  align-items: center;
+}
+
+.weekSelector .currentWeek {
+  flex: 1;
+  text-align: center;
+}


### PR DESCRIPTION
Despite the valuable comments in #198, I would suggest the design I already shown in #198 (see GIF below) to show more than 
5 days for the food tab. 

I've been trying around for a while now and feel this design is the most user friendly.

In combination with the recent changes regarding the restaurant listing, the design is not too intrusive and helps with the usability regarding the week selection.

![Aufzeichnung-2023-03-08-031453](https://user-images.githubusercontent.com/39560569/223602229-951b26b2-a99f-482a-a672-c2f378583c30.gif) 