### PR TITLE
Improves display of soups

### DIFF
--- a/rogue-thi-app/pages/food.js
+++ b/rogue-thi-app/pages/food.js
@@ -185,16 +185,6 @@ export default function Mensa () {
         {mensa.length > 0 && (
           <>
             <h4 className={styles.kindHeader}>Mensa</h4>
-            {soups.length > 0 && (
-              <>
-                {food.length > 0 && (
-                  <h5 className={styles.kindHeader}>Suppe</h5>
-                )}
-                <ListGroup>
-                  {soups.map((meal, idx) => renderMealEntry(meal, `soup-${idx}`))}
-                </ListGroup>
-              </>
-            )}
             {food.length > 0 && (
               <>
                 {soups.length > 0 && (
@@ -202,6 +192,16 @@ export default function Mensa () {
                 )}
                 <ListGroup>
                   {food.map((meal, idx) => renderMealEntry(meal, `food-${idx}`))}
+                </ListGroup>
+              </>
+            )}
+            {soups.length > 0 && (
+              <>
+                {food.length > 0 && (
+                  <h5 className={styles.kindHeader}>Suppe</h5>
+                )}
+                <ListGroup>
+                  {soups.map((meal, idx) => renderMealEntry(meal, `soup-${idx}`))}
                 </ListGroup>
               </>
             )}

--- a/rogue-thi-app/pages/food.js
+++ b/rogue-thi-app/pages/food.js
@@ -188,7 +188,7 @@ export default function Mensa () {
             {food.length > 0 && (
               <>
                 {soups.length > 0 && (
-                  <h5 className={styles.kindHeader}>Essen</h5>
+                  <h5 className={styles.kindHeader}>Gerichte</h5>
                 )}
                 <ListGroup>
                   {food.map((meal, idx) => renderMealEntry(meal, `food-${idx}`))}
@@ -198,7 +198,7 @@ export default function Mensa () {
             {soups.length > 0 && (
               <>
                 {food.length > 0 && (
-                  <h5 className={styles.kindHeader}>Suppe</h5>
+                  <h5 className={styles.kindHeader}>Suppen</h5>
                 )}
                 <ListGroup>
                   {soups.map((meal, idx) => renderMealEntry(meal, `soup-${idx}`))}

--- a/rogue-thi-app/pages/food.js
+++ b/rogue-thi-app/pages/food.js
@@ -175,28 +175,39 @@ export default function Mensa () {
    * @returns {JSX.Element}
    */
   function renderMealDay (day, key) {
+    const mensa = day.meals.filter(x => x.restaurant === 'Mensa')
     const soups = day.meals.filter(x => x.category === 'Suppe')
-    const mensa = day.meals.filter(x => x.restaurant === 'Mensa' && x.category !== 'Suppe')
+    const food = day.meals.filter(x => x.restaurant === 'Mensa' && x.category !== 'Suppe')
     const reimanns = day.meals.filter(x => x.restaurant === 'Reimanns')
 
     return (
       <SwipeableTab title={buildLinedWeekdaySpan(day.timestamp)} key={key}>
-        {soups.length > 0 && (
-          <>
-            <h4 className={styles.kindHeader}>Suppe</h4>
-            <ListGroup>
-              {soups.map((meal, idx) => renderMealEntry(meal, `soup-${idx}`))}
-            </ListGroup>
-          </>
-        )}
         {mensa.length > 0 && (
           <>
             <h4 className={styles.kindHeader}>Mensa</h4>
-            <ListGroup>
-              {mensa.map((meal, idx) => renderMealEntry(meal, `meal-${idx}`))}
-            </ListGroup>
+            {soups.length > 0 && (
+              <>
+                {food.length > 0 && (
+                  <h5 className={styles.kindHeader}>Suppe</h5>
+                )}
+                <ListGroup>
+                  {soups.map((meal, idx) => renderMealEntry(meal, `soup-${idx}`))}
+                </ListGroup>
+              </>
+            )}
+            {food.length > 0 && (
+              <>
+                {soups.length > 0 && (
+                  <h5 className={styles.kindHeader}>Essen</h5>
+                )}
+                <ListGroup>
+                  {food.map((meal, idx) => renderMealEntry(meal, `food-${idx}`))}
+                </ListGroup>
+              </>
+            )}
           </>
         )}
+
         {reimanns.length > 0 && (
           <>
             <h4 className={styles.kindHeader}>Reimanns</h4>

--- a/rogue-thi-app/pages/food.js
+++ b/rogue-thi-app/pages/food.js
@@ -176,8 +176,8 @@ export default function Mensa () {
    */
   function renderMealDay (day, key) {
     const mensa = day.meals.filter(x => x.restaurant === 'Mensa')
-    const soups = day.meals.filter(x => x.category === 'Suppe')
-    const food = day.meals.filter(x => x.restaurant === 'Mensa' && x.category !== 'Suppe')
+    const mensaSoups = day.meals.filter(x => x.restaurant === 'Mensa' && x.category === 'Suppe')
+    const mensaFood = day.meals.filter(x => x.restaurant === 'Mensa' && x.category !== 'Suppe')
     const reimanns = day.meals.filter(x => x.restaurant === 'Reimanns')
 
     return (
@@ -185,23 +185,23 @@ export default function Mensa () {
         {mensa.length > 0 && (
           <>
             <h4 className={styles.kindHeader}>Mensa</h4>
-            {food.length > 0 && (
+            {mensaFood.length > 0 && (
               <>
-                {soups.length > 0 && (
+                {mensaSoups.length > 0 && (
                   <h5 className={styles.kindHeader}>Gerichte</h5>
                 )}
                 <ListGroup>
-                  {food.map((meal, idx) => renderMealEntry(meal, `food-${idx}`))}
+                  {mensaFood.map((meal, idx) => renderMealEntry(meal, `food-${idx}`))}
                 </ListGroup>
               </>
             )}
-            {soups.length > 0 && (
+            {mensaSoups.length > 0 && (
               <>
-                {food.length > 0 && (
+                {mensaFood.length > 0 && (
                   <h5 className={styles.kindHeader}>Suppen</h5>
                 )}
                 <ListGroup>
-                  {soups.map((meal, idx) => renderMealEntry(meal, `soup-${idx}`))}
+                  {mensaSoups.map((meal, idx) => renderMealEntry(meal, `soup-${idx}`))}
                 </ListGroup>
               </>
             )}


### PR DESCRIPTION
Previously, three categories were displayed (Suppe, Mensa, Reimanns).
Thus, it was not obvious where to find the soups. Also, the design consistency was violated by the canteens as the headline.

The pull request adds two submenus to Mensa, where soups and food are displayed separately.
On days when there is no soup, the second heading is omitted.
In addition, the soups are now displayed below the food, as they are probably less relevant for most users. 


> **Note**
> Please use squash when merging. :)

![IMG_3271 (2)](https://user-images.githubusercontent.com/53063597/225098858-5e6f0d50-f9ad-4961-806e-27c56228f3b1.png)
![IMG_3272 (2)](https://user-images.githubusercontent.com/53063597/225098857-1b9e7911-e39f-4957-95dc-923061ca00b3.png)
