### PR TITLE
Simplifies Pride Theme

### DIFF
--- a/rogue-thi-app/scss/themes/pride.scss
+++ b/rogue-thi-app/scss/themes/pride.scss
@@ -1,45 +1,5 @@
-$theme-colors: (
-  "primary": #9C27B0
-);
+@import "default.scss";
 
-@import "dark.scss";
-$body-bg: black;
-
-@import "../../node_modules/bootstrap/scss/bootstrap";
-
-// react-placeholder
-// declare after bootstrap, since we need bootstrap variables
-.text-row, .rect-shape, .round-shape {
-  background: $gray-200 !important;
-}
-
-.navbar.fixed-top {
-  background: linear-gradient(180deg, #e12619 16.66%,
-    #f28500 16.67%, #f28500 33.33%,
-    #e7c815 33.34%, #e7c815 49.99%,
-    #3e9141 50%, #3e9141 66.66%,
-    #216fd6 66.67%, #216fd6 83.33%,
-    #9C27B0 83.34%) content-box !important;
-}
-
-
-.navbar-brand {
-  border-image: linear-gradient(90deg, #e12619 16.66%,
-    #f28500 16.67%, #f28500 33.33%,
-    #e7c815 33.34%, #e7c815 49.99%,
-    #3e9141 50%, #3e9141 66.66%,
-    #216fd6 66.67%, #216fd6 83.33%,
-    #9C27B0 83.34%) 0 1 stretch !important;
-}
-
-.navbar-light .navbar-brand {
-  font-weight: bold;
-  color: #9C27B0;
-  background: black;
-  height: 100%;
-}
-
-.navbar-nav, .navbar-nav .btn-link, .navbar-nav .dropdown {
-  color: #9C27B0;
-  height: 100%;
+:root {
+  --navbar-border-image: linear-gradient(90deg, #F44336 16.66%, #FF9800 16.67%, #FF9800 33.33%, #FFEB3B 33.34%, #FFEB3B 49.99%, #4CAF50 50%, #4CAF50 66.66%, #2196F3 66.67%, #2196F3 83.33%, #9C27B0 83.34%);
 }

--- a/rogue-thi-app/styles/AppNavbar.module.css
+++ b/rogue-thi-app/styles/AppNavbar.module.css
@@ -27,8 +27,9 @@
   display: inline;
   margin: 0px 10px;
   border-bottom: 2px solid transparent;
-  border-image: linear-gradient(to right, #009664, #96BE00, #D7D700, #F08200, #E6320F, #871932) 1 0 stretch;
+  border-image: var(--navbar-border-image, linear-gradient(to right, #009664, #96BE00, #D7D700, #F08200, #E6320F, #871932)) 1 0 stretch;
 }
+
 .titleTextPride {
   display: inline;
   margin: 0px 10px;


### PR DESCRIPTION
As suggested in #207, I have updated the Pride theme. It is now much simpler and contains the former default rainbow line.

In the long run, the plan is to add more details and easter eggs, which is why I kept the automatic June-Pride-Mode in the default theme.

![Simulator Screen Shot - iPhone 14 Pro Max - 2023-03-14 at 21 58 06 2](https://user-images.githubusercontent.com/53063597/225135136-022d1e84-5ad0-4e43-bd80-74f8d9275403.JPEG)