### PR TITLE
Day filler fix in food tabs

### DIFF
--- a/rogue-thi-app/pages/food.js
+++ b/rogue-thi-app/pages/food.js
@@ -234,10 +234,11 @@ export default function Mensa () {
   }
 
   const dayFiller = Array.from({ length: 5 - currentFoodDays?.length }, (_, i) => i).map((x, idx) => {
-    const day = new Date()
-    day.setDate(day.getDate() + idx)
+    const day = currentFoodDays?.length > 0 ? new Date(currentFoodDays[0].timestamp) : new Date()
+    day.setDate(day.getDate() - idx - 1)
     return { title: buildLinedWeekdaySpan(day), key: idx }
   })
+  dayFiller.reverse()
 
   return (
     <AppContainer>


### PR DESCRIPTION
Day fillers in the current week ended with the current day:
![image](https://user-images.githubusercontent.com/39560569/226569119-704017c4-c72f-4536-bce2-bf2179c88336.png)

Fixed:
![localhost_3000_food(iPhone 12 Pro) (2)](https://user-images.githubusercontent.com/39560569/226568110-d5398716-9550-42b1-9b3a-a0fe99d541b2.png)
