### PR TITLE
💄 add room of gap-end lecture

### DIFF
--- a/rogue-thi-app/pages/rooms/suggestions.js
+++ b/rogue-thi-app/pages/rooms/suggestions.js
@@ -94,6 +94,7 @@ export default function RoomSearch () {
                 {result.gap.startLecture ? getTimetableEntryName(result.gap.startLecture).shortName : 'Jetzt'}
                 <FontAwesomeIcon icon={faArrowRight} className={styles.icon} />
                 {getTimetableEntryName(result.gap.endLecture).shortName}
+                {` (${result.gap.endLecture.raum})`}
 
                 <div className={styles.time}>
                   {'Pause von '}


### PR DESCRIPTION
- Shows the room of the lecture at the end of each gap to apprehend and verify the room suggestions

![image](https://user-images.githubusercontent.com/39560569/234562645-f05c5214-88f4-4151-837a-17ad3c9bee36.png)

copilot:all