### PR TITLE
🐛 Accounts for 10-minute lead time for valid room time

### DIFF
--- a/rogue-thi-app/lib/backend-utils/timetable-utils.js
+++ b/rogue-thi-app/lib/backend-utils/timetable-utils.js
@@ -36,7 +36,7 @@ export function getTimetableEntryName (item) {
  * @returns {object[]}
  **/
 export function getTimetableGaps (timetable) {
-  const gaps = []
+  let gaps = []
   for (let i = 0; i < timetable.length - 1; i++) {
     const gap = {
       startDate: timetable[i].endDate,
@@ -56,6 +56,14 @@ export function getTimetableGaps (timetable) {
       endLecture: timetable[0]
     })
   }
+
+  gaps.forEach(x => {
+    // substract 10 minutes for valid room times
+    x.endDate.setMinutes(x.endDate.getMinutes() - 10)
+  })
+
+  // filter out gaps that are too short (<= 10 minutes) (10 minute are already substracted => 0)
+  gaps = gaps.filter(x => x.endDate - x.startDate > 0)
 
   return gaps
 }


### PR DESCRIPTION
The current room suggestions didn't account for a 10-minute head gap required for valid room searches.

**Current:**
- gap ends at 13:15
- room suggestions search for rooms that are free at 13:15 (-> new time slot that might be occupied)

**Fixed:**
- gap ends at 13:15
- room suggestions search for rooms that are free at 13:05 (-> align with THI time slots)

Additionally, gaps that are shorter or equal than 10 minutes will be ignored.
![www3 primuss de_stpl_index php_FH=fhin Language=de(Nest Hub Max)
](https://user-images.githubusercontent.com/39560569/235904045-9d1410c6-9aad-4dd4-8721-f92c1427f7c0.png)

![dev neuland app_rooms_suggestions(iPhone 14 Pro Max)](https://user-images.githubusercontent.com/39560569/235904063-0ce0584b-613e-4f7d-a0f9-2e30af74b91a.png)




copilot: all