### PR TITLE
Simplifies timetable page

### DIFF
--- a/rogue-thi-app/lib/backend-utils/timetable-utils.js
+++ b/rogue-thi-app/lib/backend-utils/timetable-utils.js
@@ -12,8 +12,7 @@ export function getTimetableEntryName (item) {
     const [shortName] = match
     return {
       name: item.fach,
-      shortName,
-      fullName: `${shortName} - ${item.fach}`
+      shortName
     }
   } else {
     // fallback for weird entries like
@@ -23,8 +22,7 @@ export function getTimetableEntryName (item) {
     const shortName = name.length < 10 ? name : name.substr(0, 10) + '…'
     return {
       name,
-      shortName,
-      fullName: name
+      shortName
     }
   }
 }

--- a/rogue-thi-app/pages/timetable.js
+++ b/rogue-thi-app/pages/timetable.js
@@ -186,7 +186,7 @@ export default function Timetable () {
                 <ListGroup.Item key={idx} className={styles.item} onClick={() => setFocusedEntry(item)} action>
                   <div className={styles.left}>
                     <div className={styles.name}>
-                      {getTimetableEntryName(item).fullName}
+                      {getTimetableEntryName(item).name}
                     </div>
                     <div className={styles.room}>
                       {item.rooms.map((room, i) => /^[A-Z](G|[0-9E]\.)?\d*$/.test(room)
@@ -314,6 +314,7 @@ export default function Timetable () {
             <h5>Allgemein</h5>
             <p>
               <strong>Dozent</strong>: {focusedEntry && focusedEntry.dozent}<br />
+              <strong>Kürzel</strong>: {focusedEntry && getTimetableEntryName(focusedEntry).shortName}<br />
               <strong>Prüfung</strong>: {focusedEntry && focusedEntry.pruefung}<br />
               <strong>Studiengang</strong>: {focusedEntry && focusedEntry.stg}<br />
               <strong>Studiengruppe</strong>: {focusedEntry && focusedEntry.stgru}<br />


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d29c043</samp>

### Summary
🔥🖼️🗒️

<!--
1.  🔥 - This emoji can represent the removal of the `fullName` property and the simplification of the code, as it implies burning or deleting something unnecessary or redundant.
2.  🖼️ - This emoji can represent the change in the timetable display, as it implies a visual or aesthetic modification, and also suggests a frame or a layout.
3.  🗒️ - This emoji can represent the addition of the `shortName` property to the modal details, as it implies a note or a summary of something longer or more detailed.
-->
Removed `fullName` property from timetable entries and used `name` and `shortName` instead. This simplifies the code and the UI for the `rogue-thi-app` feature.

> _No more `fullName`, only `name`_
> _Simpler code, no more pain_
> _Show the `shortName` in the modal light_
> _Timetable of doom, ready for the fight_

### Walkthrough
*  Remove `fullName` property from timetable entry objects and use `name` and `shortName` instead ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/248/files?diff=unified&w=0#diff-017e3a6434af0820a1df8559840dfac59e199a554f7b96980e0369f562b304f3L15-R15), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/248/files?diff=unified&w=0#diff-017e3a6434af0820a1df8559840dfac59e199a554f7b96980e0369f562b304f3L26-R25), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/248/files?diff=unified&w=0#diff-d4cf89661961b284068dd1daec5bfe7909337528e70b946af09dded1a81ff4c5L189-R189), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/248/files?diff=unified&w=0#diff-d4cf89661961b284068dd1daec5bfe7909337528e70b946af09dded1a81ff4c5R317))

