### PR TITLE
🐛 Save user language preference

### DIFF
--- a/rogue-thi-app/components/modal/LanguageModal.js
+++ b/rogue-thi-app/components/modal/LanguageModal.js
@@ -30,6 +30,7 @@ export default function LanguageModal () {
     setShowLanguageModal(false)
     i18n.changeLanguage(languageKey)
     router.replace('/', '', { locale: i18n.language })
+    document.cookie = `NEXT_LOCALE=${i18n.language}; path=/`
   }
 
   return (

--- a/rogue-thi-app/next.config.js
+++ b/rogue-thi-app/next.config.js
@@ -1,3 +1,5 @@
+const { i18n } = require('./next-i18next.config')
+
 // https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md
 const permissionPolicyFeatures = [
   'accelerometer',
@@ -29,10 +31,8 @@ const isDev = process.env.NODE_ENV === 'development'
 const DEEPL_ENDPOINT = process.env.NEXT_PUBLIC_DEEPL_ENDPOINT || ''
 
 module.exports = {
-  i18n: {
-    locales: ['en', 'de'],
-    defaultLocale: 'en'
-  },
+  i18n,
+  trailingSlash: true,
   async headers () {
     return [
       {


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 35e2f67</samp>

### Summary
🍪🌐🔗

<!--
1.  🍪 for setting a cookie with the language preference
2.  🌐 for improving internationalization support
3.  🔗 for adding the `trailingSlash` option
-->
This pull request improves the internationalization of the `rogue-thi-app` by refactoring the Next.js configuration and setting a language cookie. These changes enable consistent and user-friendly language switching across the app.

> _Oh we are the coders of the `Next.js` ship_
> _And we sail the web with a mighty grip_
> _We set the `next_locale` cookie with a click_
> _And we refactor the config to make it slick_

### Walkthrough
*  Persist user language preference with a cookie ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/290/files?diff=unified&w=0#diff-cba054d51afa966a2b32b353b1b05107316470cfc72d260b8f5df5f40bba012cR33))
*  Import i18n configuration from a separate file to avoid duplication ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/290/files?diff=unified&w=0#diff-64d194c8ffd1cb08dc3e9ba5c9ac339ad85abe7c212d905c435e1b705ab37c08R1-R2))
*  Enable trailing slash for every route to prevent redirection issues with `next-i18next` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/290/files?diff=unified&w=0#diff-64d194c8ffd1cb08dc3e9ba5c9ac339ad85abe7c212d905c435e1b705ab37c08L32-R35))

