### PR TITLE
Suggestions fixes

### DIFF
--- a/rogue-thi-app/components/RoomMap.js
+++ b/rogue-thi-app/components/RoomMap.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
 
 import Link from 'next/link'
@@ -10,7 +10,7 @@ import { AttributionControl, CircleMarker, FeatureGroup, LayerGroup, LayersContr
 
 import { NoSessionError, UnavailableSessionError } from '../lib/backend/thi-session-handler'
 import { USER_GUEST, useUserKind } from '../lib/hooks/user-kind'
-import { filterRooms, getNextValidDate } from '../lib/backend-utils/rooms-utils'
+import { filterRooms, getNextValidDate, getTranslatedRoomFunction } from '../lib/backend-utils/rooms-utils'
 import { formatFriendlyTime, formatISODate, formatISOTime } from '../lib/date-utils'
 import { useLocation } from '../lib/hooks/geolocation'
 
@@ -58,13 +58,6 @@ export default function RoomMap ({ highlight, roomData }) {
 
   const { t, i18n } = useTranslation(['rooms', 'api-translations'])
 
-  const getTranslatedFunction = useCallback((room) => {
-    const roomFunctionCleaned = room?.properties?.Funktion?.replace(/\s+/g, ' ')?.trim() ?? ''
-
-    const roomFunction = t(`apiTranslations.roomFunctions.${roomFunctionCleaned}`, { ns: 'api-translations' })
-    return roomFunction === `apiTranslations.roomFunctions.${roomFunctionCleaned}` ? roomFunctionCleaned : roomFunction
-  }, [t])
-
   /**
    * Preprocessed room data for Leaflet.
    */
@@ -105,7 +98,7 @@ export default function RoomMap ({ highlight, roomData }) {
 
     const getProp = (room, prop) => {
       if (prop === 'Funktion') {
-        return getTranslatedFunction(room).toUpperCase()
+        return getTranslatedRoomFunction(room?.properties?.Funktion).toUpperCase()
       }
 
       return room.properties[prop]?.toUpperCase()
@@ -126,7 +119,7 @@ export default function RoomMap ({ highlight, roomData }) {
     const filteredCenter = count > 0 ? [lon / count, lat / count] : DEFAULT_CENTER
 
     return [filtered, filteredCenter]
-  }, [searchText, allRooms, getTranslatedFunction])
+  }, [searchText, allRooms])
 
   useEffect(() => {
     async function load () {
@@ -199,7 +192,7 @@ export default function RoomMap ({ highlight, roomData }) {
           <strong>
             {entry.properties.Raum}
           </strong>
-          {`, ${getTranslatedFunction(entry, i18n)}`} <br />
+          {`, ${getTranslatedRoomFunction(entry?.properties?.Funktion, i18n)}`} <br />
           {avail && (
             <>
               {t('rooms.map.freeFromUntil', {

--- a/rogue-thi-app/components/cards/RoomCard.js
+++ b/rogue-thi-app/components/cards/RoomCard.js
@@ -6,7 +6,7 @@ import { faDoorOpen } from '@fortawesome/free-solid-svg-icons'
 
 import BaseCard from './BaseCard'
 
-import { findSuggestedRooms, getEmptySuggestions } from '../../lib/backend-utils/rooms-utils'
+import { findSuggestedRooms, getEmptySuggestions, getTranslatedRoomName } from '../../lib/backend-utils/rooms-utils'
 import { formatFriendlyTime, isSameDay } from '../../lib/date-utils'
 import { getFriendlyTimetable, getTimetableGaps } from '../../lib/backend-utils/timetable-utils'
 import { NoSessionError } from '../../lib/backend/thi-session-handler'
@@ -84,7 +84,7 @@ export default function RoomCard () {
                 <Link href={'/rooms/suggestions'}>
                   <div>
                     <div>
-                      {x.room}
+                      {getTranslatedRoomName(x.room)}
                     </div>
                     <div className="text-muted">
                       {t('rooms.text', { from: formatFriendlyTime(x.from), until: formatFriendlyTime(x.until) })}

--- a/rogue-thi-app/lib/backend-utils/rooms-utils.js
+++ b/rogue-thi-app/lib/backend-utils/rooms-utils.js
@@ -316,25 +316,24 @@ export async function getEmptySuggestions (asGap = false) {
 
       if (filteredRooms.length >= 4) {
         // enough rooms in preferred buildings -> filter out other buildings
-        console.log('enough rooms in preferred buildings -> filter out other buildings')
         rooms = filteredRooms
       } else {
         // not enough rooms in preferred buildings -> show all rooms but sort by preferred buildings
-        console.log('not enough rooms in preferred buildings -> show all rooms but sort by preferred buildings')
         rooms = rooms.sort(x => filteredBuildings.some(y => isInBuilding(x.room, y)))
       }
     }
-  } else {
-    // no preferred buildings -> search rooms near majority room
-    const majorityRoom = await getMajorityRoom()
+  }
 
-    // if majority room is undefined -> do not filter
-    if (majorityRoom) {
-      rooms = sortRoomsByDistance(majorityRoom, rooms)
+  // no preferred buildings -> search rooms near majority room
+  // preferred buildings -> filter by preferred buildings and sort by distance to majority room
+  const majorityRoom = await getMajorityRoom()
 
-      // hide Neuburg buildings if next lecture is not in Neuburg
-      rooms = rooms.filter(x => x.room.includes('N') === majorityRoom.includes('N'))
-    }
+  // if majority room is undefined -> do not filter
+  if (majorityRoom) {
+    rooms = sortRoomsByDistance(majorityRoom, rooms)
+
+    // hide Neuburg buildings if next lecture is not in Neuburg
+    rooms = rooms.filter(x => x.room.includes('N') === majorityRoom.includes('N'))
   }
 
   rooms = rooms.slice(0, 4)

--- a/rogue-thi-app/lib/backend-utils/rooms-utils.js
+++ b/rogue-thi-app/lib/backend-utils/rooms-utils.js
@@ -1,13 +1,16 @@
 import API from '../backend/authenticated-api'
-import { formatISODate } from '../date-utils'
+
+import { formatISODate, getWeek } from '../date-utils'
 import { getFriendlyTimetable } from './timetable-utils'
+import { i18n } from 'next-i18next'
 import roomDistances from '../../data/room-distances.json'
 
 const IGNORE_GAPS = 15
 
+export const BUILDINGS = ['A', 'B', 'BN', 'C', 'CN', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'M', 'P', 'W', 'Z']
 export const BUILDINGS_ALL = 'Alle'
 export const DURATION_PRESET = '01:00'
-const SUGGESTION_DURATION_PRESET = 90
+export const SUGGESTION_DURATION_PRESET = 90
 
 /**
  * Adds minutes to a date object.
@@ -212,6 +215,19 @@ function sortRoomsByDistance (room, rooms) {
 }
 
 /**
+ * Returns all buildings filtered by Neuburg or Ingolstadt using the timetable.
+ */
+export async function getAllUserBuildings () {
+  const majorityRoom = await getMajorityRoom()
+
+  if (majorityRoom) {
+    return BUILDINGS.filter(building => building.includes('N') === majorityRoom.includes('N'))
+  }
+
+  return BUILDINGS
+}
+
+/**
  * Finds rooms that are close to the given room and are available for the given time.
  * @param {string} room Room name (e.g. `G215`)
  * @param {Date} startDate Start date as Date object
@@ -235,10 +251,24 @@ export async function findSuggestedRooms (room, startDate, endDate) {
  * @returns {string} Room name (e.g. `G215`)
  */
 async function getMajorityRoom () {
-  const timetable = await getFriendlyTimetable(new Date(), false)
+  const date = new Date()
+  if (date.getDay() === 0) {
+    date.setDate(date.getDate() + 1)
+  }
+
+  const week = getWeek(date)
+
+  const timetable = await getFriendlyTimetable(week[0], false)
   const rooms = timetable.map(x => x.raum)
 
   return mode(rooms)
+}
+
+export function getTranslatedRoomFunction (roomFunction) {
+  const roomFunctionCleaned = roomFunction?.replace(/\s+/g, ' ')?.trim() ?? ''
+
+  const translatedRoomFunction = i18n.t(`apiTranslations.roomFunctions.${roomFunctionCleaned}`, { ns: 'api-translations' })
+  return translatedRoomFunction === `apiTranslations.roomFunctions.${roomFunctionCleaned}` ? roomFunctionCleaned : translatedRoomFunction
 }
 
 /**
@@ -247,15 +277,36 @@ async function getMajorityRoom () {
  * @param {number} [duration] Duration of the gap in minutes
  * @returns {Array}
  **/
-export async function getEmptySuggestions (asGap = false, duration = SUGGESTION_DURATION_PRESET) {
-  const endDate = addMinutes(new Date(), duration)
+export async function getEmptySuggestions (asGap = false) {
+  const userDurationStorage = localStorage.getItem('suggestion-duration')
+  const userDuration = userDurationStorage ? parseInt(userDurationStorage) : SUGGESTION_DURATION_PRESET
+
+  const endDate = addMinutes(new Date(), userDuration)
   let rooms = await searchRooms(new Date(), endDate)
 
-  const majorityRoom = await getMajorityRoom()
-  rooms = sortRoomsByDistance(majorityRoom, rooms)
+  const buildingFilter = localStorage.buildingPreferences
 
-  // hide Neuburg buildings if next lecture is not in Neuburg
-  rooms = rooms.filter(x => x.room.includes('N') === majorityRoom.includes('N'))
+  if (buildingFilter) {
+    // test if any of the rooms is in any of the user's preferred buildings
+    const userBuildings = JSON.parse(buildingFilter)
+    const filteredBuildings = Object.keys(userBuildings).filter(x => userBuildings[x])
+
+    if (filteredBuildings.length !== 0) {
+      rooms = rooms.filter(x => filteredBuildings.some(y => isInBuilding(x.room, y)))
+    }
+  } else {
+    // no preferred buildings -> search rooms near majority room
+    const majorityRoom = await getMajorityRoom()
+
+    // if majority room is undefined -> do not filter
+    if (majorityRoom) {
+      rooms = sortRoomsByDistance(majorityRoom, rooms)
+
+      // hide Neuburg buildings if next lecture is not in Neuburg
+      rooms = rooms.filter(x => x.room.includes('N') === majorityRoom.includes('N'))
+    }
+  }
+
   rooms = rooms.slice(0, 4)
 
   if (asGap) {

--- a/rogue-thi-app/lib/backend-utils/rooms-utils.js
+++ b/rogue-thi-app/lib/backend-utils/rooms-utils.js
@@ -285,7 +285,7 @@ export function getTranslatedRoomFunction (roomFunction) {
 export function getTranslatedRoomName (room) {
   switch (room) {
     case 'alle Räume':
-      return i18n.t('rooms.common.allRooms', { ns: 'rooms' })
+      return i18n.t('rooms.allRooms', { ns: 'common' })
     default:
       return room
   }

--- a/rogue-thi-app/lib/hooks/building-filter.js
+++ b/rogue-thi-app/lib/hooks/building-filter.js
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+
+export function useBuildingFilter () {
+  const [buildingPreferences, setBuildingPreferences] = useState({})
+
+  useEffect(() => {
+    if (localStorage.buildingPreferences) {
+      setBuildingPreferences(JSON.parse(localStorage.buildingPreferences))
+    }
+  }, [])
+
+  /**
+   * Persists the building preferences to localStorage.
+   */
+  function saveBuildingPreferences () {
+    localStorage.buildingPreferences = JSON.stringify(buildingPreferences)
+  }
+
+  return {
+    buildingPreferences,
+    setBuildingPreferences,
+    saveBuildingPreferences
+  }
+}

--- a/rogue-thi-app/pages/rooms/search.js
+++ b/rogue-thi-app/pages/rooms/search.js
@@ -15,7 +15,7 @@ import AppContainer from '../../components/page/AppContainer'
 import AppNavbar from '../../components/page/AppNavbar'
 import AppTabbar from '../../components/page/AppTabbar'
 
-import { BUILDINGS_ALL, DURATION_PRESET, filterRooms, getNextValidDate } from '../../lib/backend-utils/rooms-utils'
+import { BUILDINGS, BUILDINGS_ALL, DURATION_PRESET, filterRooms, getNextValidDate } from '../../lib/backend-utils/rooms-utils'
 import { NoSessionError, UnavailableSessionError } from '../../lib/backend/thi-session-handler'
 import { formatFriendlyTime, formatISODate, formatISOTime } from '../../lib/date-utils'
 
@@ -24,7 +24,6 @@ import styles from '../../styles/RoomsSearch.module.css'
 import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
-const BUILDINGS = ['A', 'B', 'BN', 'C', 'CN', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'M', 'P', 'W', 'Z']
 const DURATIONS = ['00:15', '00:30', '00:45', '01:00', '01:15', '01:30', '01:45', '02:00', '02:15', '02:30', '02:45', '03:00', '03:15', '03:30', '03:45', '04:00', '04:15', '04:30', '04:45', '05:00', '05:15', '05:30', '05:45', '06:00']
 const TUX_ROOMS = ['G308']
 

--- a/rogue-thi-app/pages/rooms/search.js
+++ b/rogue-thi-app/pages/rooms/search.js
@@ -15,7 +15,7 @@ import AppContainer from '../../components/page/AppContainer'
 import AppNavbar from '../../components/page/AppNavbar'
 import AppTabbar from '../../components/page/AppTabbar'
 
-import { BUILDINGS, BUILDINGS_ALL, DURATION_PRESET, filterRooms, getNextValidDate } from '../../lib/backend-utils/rooms-utils'
+import { BUILDINGS, BUILDINGS_ALL, DURATION_PRESET, filterRooms, getNextValidDate, getTranslatedRoomFunction, getTranslatedRoomName } from '../../lib/backend-utils/rooms-utils'
 import { NoSessionError, UnavailableSessionError } from '../../lib/backend/thi-session-handler'
 import { formatFriendlyTime, formatISODate, formatISOTime } from '../../lib/date-utils'
 
@@ -31,7 +31,8 @@ export const getStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'en', [
       'rooms',
-      'common'
+      'common',
+      'api-translations'
     ]))
   }
 })
@@ -149,11 +150,11 @@ export default function RoomSearch () {
                 <ListGroup.Item key={idx} className={styles.item}>
                   <div className={styles.left}>
                     <Link href={`/rooms?highlight=${result.room}`}>
-                      {result.room}
+                      {getTranslatedRoomName(result.room)}
                     </Link>
                     {TUX_ROOMS.includes(result.room) && <> <FontAwesomeIcon title="Linux" icon={faLinux} /></>}
                     <div className={styles.details}>
-                      {result.type}
+                      {getTranslatedRoomFunction(result.type)}
                     </div>
                   </div>
                   <div className={styles.right}>

--- a/rogue-thi-app/pages/rooms/search.js
+++ b/rogue-thi-app/pages/rooms/search.js
@@ -58,6 +58,12 @@ export default function RoomSearch () {
    * Searches and displays rooms with the specified filters.
    */
   const filter = useCallback(async () => {
+    // when entering dates on desktop, for a short time the date is invalid (e.g. 2023-07-00) when the user is still typing
+    const validateDate = new Date(date)
+    if (isNaN(validateDate.getTime())) {
+      return
+    }
+
     setSearching(true)
     setFilterResults(null)
 

--- a/rogue-thi-app/pages/rooms/suggestions.js
+++ b/rogue-thi-app/pages/rooms/suggestions.js
@@ -5,6 +5,12 @@ import { useRouter } from 'next/router'
 import ListGroup from 'react-bootstrap/ListGroup'
 import ReactPlaceholder from 'react-placeholder'
 
+import Button from 'react-bootstrap/Button'
+import ButtonGroup from 'react-bootstrap/ButtonGroup'
+import Container from 'react-bootstrap/Container'
+import Form from 'react-bootstrap/Form'
+import Modal from 'react-bootstrap/Modal'
+
 import { faArrowRight, faCalendar } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faLinux } from '@fortawesome/free-brands-svg-icons'
@@ -17,7 +23,7 @@ import AppTabbar from '../../components/page/AppTabbar'
 import { NoSessionError, UnavailableSessionError } from '../../lib/backend/thi-session-handler'
 import { formatFriendlyTime, isSameDay } from '../../lib/date-utils'
 
-import { findSuggestedRooms, getEmptySuggestions } from '../../lib/backend-utils/rooms-utils'
+import { SUGGESTION_DURATION_PRESET, findSuggestedRooms, getAllUserBuildings, getEmptySuggestions, getTranslatedRoomFunction } from '../../lib/backend-utils/rooms-utils'
 
 import styles from '../../styles/RoomsSearch.module.css'
 
@@ -26,6 +32,7 @@ import { getFriendlyTimetable, getTimetableEntryName, getTimetableGaps } from '.
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
 import { Trans, useTranslation } from 'next-i18next'
+import { useBuildingFilter } from '../../lib/hooks/building-filter'
 
 const TUX_ROOMS = ['G308']
 
@@ -33,6 +40,7 @@ export const getStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'en', [
       'rooms',
+      'api-translations',
       'common'
     ]))
   }
@@ -45,6 +53,10 @@ export default function RoomSearch () {
   const router = useRouter()
 
   const [suggestions, setSuggestions] = useState(null)
+  const [showEditDuration, setShowEditDuration] = useState(false)
+  const [buildings, setBuildings] = useState([])
+
+  const { buildingPreferences, setBuildingPreferences, saveBuildingPreferences } = useBuildingFilter()
 
   const userKind = useUserKind()
 
@@ -53,6 +65,9 @@ export default function RoomSearch () {
   useEffect(() => {
     async function load () {
       try {
+        // load buildings
+        setBuildings(await getAllUserBuildings())
+
         // get timetable and filter for today
         const timetable = await getFriendlyTimetable(new Date(), false)
         const today = timetable.filter(x => isSameDay(x.startDate, new Date()))
@@ -98,11 +113,135 @@ export default function RoomSearch () {
     }
   }, [router, userKind])
 
+  async function closeModal () {
+    setShowEditDuration(false)
+    saveBuildingPreferences()
+
+    const suggestions = await getEmptySuggestions(true)
+    setSuggestions(suggestions)
+  }
+
+  /**
+ * Returns the header for the given result like `Jetzt -> KI_ML3 (K015)`
+ * @param {object} result Gap result object
+ * @returns {JSX.Element} Header
+ */
+  function GapHeader ({ result }) {
+    if (result.gap.endLecture) {
+      return (
+      <Trans
+        i18nKey="rooms.suggestions.gaps.header.specific"
+        ns='rooms'
+        components={{
+          arrow: <FontAwesomeIcon icon={faArrowRight} className={styles.icon} />
+        }}
+        values={{
+          from: result.gap.startLecture ? getTimetableEntryName(result.gap.startLecture).shortName : t('rooms.suggestions.gaps.now'),
+          until: getTimetableEntryName(result.gap.endLecture).shortName,
+          room: result.gap.endLecture.raum
+        }}
+      />
+      )
+    } else {
+      return (
+      <Trans
+        i18nKey="rooms.suggestions.gaps.header.general"
+        ns='rooms'
+      />
+      )
+    }
+  }
+
+  /**
+ * Returns the subtitle for the given result like `Pause von 10:00 bis 10:15`
+ * @param {object} result Gap result object
+ * @returns {JSX.Element} Subtitle
+ **/
+  function GapSubtitle ({ result }) {
+    if (result.gap.endLecture) {
+      return (
+      <Trans
+        i18nKey="rooms.suggestions.gaps.subtitle.specific"
+        ns='rooms'
+        values={{
+          from: result.gap.startLecture ? formatFriendlyTime(result.gap.startLecture.endDate) : t('rooms.suggestions.gaps.now').toLowerCase(),
+          until: formatFriendlyTime(result.gap.endLecture.startDate),
+          room: result.gap.endLecture.raum
+        }}
+      />
+      )
+    } else {
+      return (
+      <Trans
+        i18nKey="rooms.suggestions.gaps.subtitle.general"
+        ns='rooms'
+        values={{
+          from: formatFriendlyTime(result.gap.startDate),
+          until: formatFriendlyTime(result.gap.endDate),
+          duration: Math.ceil((result.gap.endDate.getTime() - result.gap.startDate.getTime()) / 1000 / 60)
+        }}
+      />
+      )
+    }
+  }
+
   return (
     <AppContainer>
-      <AppNavbar title={t('rooms.suggestions.appbar.title')} />
+      <AppNavbar title={t('rooms.suggestions.appbar.title')}>
+        <AppNavbar.Overflow>
+          <AppNavbar.Overflow.Link variant="link" onClick={() => setShowEditDuration(true)}>
+            {t('rooms.suggestions.appbar.overflow.suggestionPreferences')}
+          </AppNavbar.Overflow.Link>
+        </AppNavbar.Overflow>
+      </AppNavbar>
 
       <AppBody>
+      <Modal size="lg" show={showEditDuration} onHide={closeModal}>
+          <Modal.Header closeButton>
+            <Modal.Title>{t('rooms.suggestions.modals.suggestionPreferences.title')}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            {t('rooms.suggestions.modals.suggestionPreferences.description')}
+            <br />
+            <br />
+            <h4>
+              {t('rooms.suggestions.modals.suggestionPreferences.duration')}
+            </h4>
+
+            <Container>
+              <ButtonGroup className={['w-100', styles.container]}>
+                <DurationButton duration={30} />
+                <DurationButton duration={60} />
+                <DurationButton duration={90} />
+                <DurationButton duration={120} />
+              </ButtonGroup>
+            </Container>
+
+            <h4>
+              {t('rooms.suggestions.modals.suggestionPreferences.preferredBuildings')}
+            </h4>
+            <Container>
+              <Form className={styles.container}>
+                {buildings.map((building, idx) =>
+                  <Form.Check
+                    key={idx}
+                    type="checkbox"
+                    id={`building-${building}`}
+                    label={building}
+                    checked={buildingPreferences[building] || false}
+                    onChange={e => setBuildingPreferences({ ...buildingPreferences, [building]: e.target.checked })}
+                  />
+                )}
+              </Form>
+            </Container>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={closeModal}>
+              {t('rooms.suggestions.modals.suggestionPreferences.close')}
+            </Button>
+          </Modal.Footer>
+        </Modal>
+
         <ReactPlaceholder type="text" rows={20} ready={suggestions || userKind === USER_GUEST}>
           {suggestions && suggestions.map((result, idx) =>
             <div key={idx}>
@@ -122,7 +261,7 @@ export default function RoomSearch () {
                       </Link>
                       {TUX_ROOMS.includes(roomResult.room) && <> <FontAwesomeIcon title="Linux" icon={faLinux} /></>}
                       <div className={styles.details}>
-                        {roomResult.type}
+                        {getTranslatedRoomFunction(roomResult.type)}
                       </div>
                     </div>
                     <div className={styles.right}>
@@ -162,66 +301,24 @@ export default function RoomSearch () {
       <AppTabbar />
     </AppContainer>
   )
-}
 
-/**
- * Returns the header for the given result like `Jetzt -> KI_ML3 (K015)`
- * @param {object} result Gap result object
- * @returns {JSX.Element} Header
- */
-function GapHeader ({ result }) {
-  if (result.gap.endLecture) {
-    return (
-      <Trans
-        i18nKey="rooms.suggestions.gaps.header.specific"
-        ns='rooms'
-        components={{
-          arrow: <FontAwesomeIcon icon={faArrowRight} className={styles.icon} />
-        }}
-        values={{
-          from: result.gap.startLecture ? getTimetableEntryName(result.gap.startLecture).shortName : 'Jetzt',
-          until: getTimetableEntryName(result.gap.endLecture).shortName,
-          room: result.gap.endLecture.raum
-        }}
-      />
-    )
-  } else {
-    return (
-      <Trans
-        i18nKey="rooms.suggestions.gaps.header.general"
-        ns='rooms'
-      />
-    )
-  }
-}
+  function DurationButton ({ duration }) {
+    const variant = (localStorage.getItem('suggestion-duration') ?? `${SUGGESTION_DURATION_PRESET}`) === `${duration}` ? 'primary' : 'outline-primary'
+    return <Button variant={variant} onClick={() => {
+      localStorage.setItem('suggestion-duration', duration)
 
-/**
- * Returns the subtitle for the given result like `Pause von 10:00 bis 10:15`
- * @param {object} result Gap result object
- * @returns {JSX.Element} Subtitle
- **/
-function GapSubtitle ({ result }) {
-  if (result.gap.endLecture) {
-    return (
-      <Trans
-        i18nKey="rooms.suggestions.gaps.subtitle.specific"
-        ns='rooms'
-        values={{
-          from: result.gap.startLecture ? formatFriendlyTime(result.gap.startLecture.endDate) : 'Jetzt',
-          until: formatFriendlyTime(result.gap.endLecture.startDate)
-        }}
-      />
-    )
-  } else {
-    return (
-      <Trans
-        i18nKey="rooms.suggestions.gaps.subtitle.general"
-        ns='rooms'
-        values={{
-          from: formatFriendlyTime(result.gap.startDate),
-          until: formatFriendlyTime(result.gap.endDate)
-        }}
-      />
-    )
+      // update page
+      const load = async () => {
+        const suggestions = await getEmptySuggestions(true)
+        setSuggestions(suggestions)
+      }
+
+      load()
+    } }>
+      <h3>
+        {duration}
+      </h3>
+      {t('rooms.suggestions.modals.suggestionPreferences.minutes')}
+    </Button>
   }
 }

--- a/rogue-thi-app/pages/rooms/suggestions.js
+++ b/rogue-thi-app/pages/rooms/suggestions.js
@@ -23,7 +23,7 @@ import AppTabbar from '../../components/page/AppTabbar'
 import { NoSessionError, UnavailableSessionError } from '../../lib/backend/thi-session-handler'
 import { formatFriendlyTime, isSameDay } from '../../lib/date-utils'
 
-import { SUGGESTION_DURATION_PRESET, findSuggestedRooms, getAllUserBuildings, getEmptySuggestions, getTranslatedRoomFunction } from '../../lib/backend-utils/rooms-utils'
+import { SUGGESTION_DURATION_PRESET, findSuggestedRooms, getAllUserBuildings, getEmptySuggestions, getTranslatedRoomFunction, getTranslatedRoomName } from '../../lib/backend-utils/rooms-utils'
 
 import styles from '../../styles/RoomsSearch.module.css'
 
@@ -113,6 +113,9 @@ export default function RoomSearch () {
     }
   }, [router, userKind])
 
+  /**
+   * Closes the modal and saves the preferences.
+   */
   async function closeModal () {
     setShowEditDuration(false)
     saveBuildingPreferences()
@@ -183,6 +186,31 @@ export default function RoomSearch () {
       />
       )
     }
+  }
+
+  /**
+   * A button to select a duration.
+   * @param {int} duration Duration in minutes
+   * @returns {JSX.Element} Button
+   */
+  function DurationButton ({ duration }) {
+    const variant = (localStorage.getItem('suggestion-duration') ?? `${SUGGESTION_DURATION_PRESET}`) === `${duration}` ? 'primary' : 'outline-primary'
+    return <Button variant={variant} onClick={() => {
+      localStorage.setItem('suggestion-duration', duration)
+
+      // update page
+      const load = async () => {
+        const suggestions = await getEmptySuggestions(true)
+        setSuggestions(suggestions)
+      }
+
+      load()
+    } }>
+      <h3>
+        {duration}
+      </h3>
+      {t('rooms.suggestions.modals.suggestionPreferences.minutes')}
+    </Button>
   }
 
   return (
@@ -257,7 +285,7 @@ export default function RoomSearch () {
                   <ListGroup.Item key={idx} className={styles.item}>
                     <div className={styles.left}>
                       <Link href={`/rooms?highlight=${roomResult.room}`}>
-                        {roomResult.room}
+                        {getTranslatedRoomName(roomResult.room)}
                       </Link>
                       {TUX_ROOMS.includes(roomResult.room) && <> <FontAwesomeIcon title="Linux" icon={faLinux} /></>}
                       <div className={styles.details}>
@@ -301,24 +329,4 @@ export default function RoomSearch () {
       <AppTabbar />
     </AppContainer>
   )
-
-  function DurationButton ({ duration }) {
-    const variant = (localStorage.getItem('suggestion-duration') ?? `${SUGGESTION_DURATION_PRESET}`) === `${duration}` ? 'primary' : 'outline-primary'
-    return <Button variant={variant} onClick={() => {
-      localStorage.setItem('suggestion-duration', duration)
-
-      // update page
-      const load = async () => {
-        const suggestions = await getEmptySuggestions(true)
-        setSuggestions(suggestions)
-      }
-
-      load()
-    } }>
-      <h3>
-        {duration}
-      </h3>
-      {t('rooms.suggestions.modals.suggestionPreferences.minutes')}
-    </Button>
-  }
 }

--- a/rogue-thi-app/pages/rooms/suggestions.js
+++ b/rogue-thi-app/pages/rooms/suggestions.js
@@ -69,16 +69,12 @@ export default function RoomSearch () {
 
     if (today.length < 1) {
       // no lectures today -> general room search
-      const suggestions = await getEmptySuggestions(true)
-      setSuggestions(suggestions)
-      return
+      return await getEmptySuggestions(true)
     }
 
     const gaps = getTimetableGaps(today)
     if (gaps.length < 1) {
-      const suggestions = await getEmptySuggestions(true)
-      setSuggestions(suggestions)
-      return
+      return await getEmptySuggestions(true)
     }
 
     const suggestions = await Promise.all(gaps.map(async (gap) => {
@@ -210,14 +206,6 @@ export default function RoomSearch () {
     const variant = (localStorage.getItem('suggestion-duration') ?? `${SUGGESTION_DURATION_PRESET}`) === `${duration}` ? 'primary' : 'outline-primary'
     return <Button variant={variant} onClick={() => {
       localStorage.setItem('suggestion-duration', duration)
-
-      // update page
-      const load = async () => {
-        const suggestions = await getEmptySuggestions(true)
-        setSuggestions(suggestions)
-      }
-
-      load()
     } }>
       <h3>
         {duration}

--- a/rogue-thi-app/public/locales/de/common.json
+++ b/rogue-thi-app/public/locales/de/common.json
@@ -67,5 +67,8 @@
     "appbar": {
         "back": "Zurück",
         "overflow": "Mehr Optionen"
+    },
+    "rooms": {
+        "allRooms": "Alle Räume"
     }
 }

--- a/rogue-thi-app/public/locales/de/rooms.json
+++ b/rogue-thi-app/public/locales/de/rooms.json
@@ -41,25 +41,39 @@
         },
         "suggestions": {
             "appbar": {
-                "title": "Raumvorschläge"
+                "title": "Raumvorschläge",
+                "overflow": {
+                    "suggestionPreferences": "Vorschlags-Präferenzen bearbeiten"
+                }
             },
             "noSuggestions": "Keine Vorschläge verfügbar.",
             "noAvailableRooms": "Keine freien Räume gefunden.",
             "gaps": {
                 "header": {
                     "general": "Freie Räume",
-                    "specific": "{{from}} <arrow/> {{until}}"
+                    "specific": "{{from}} <arrow/> {{until}} ({{room}})"
                 },
                 "subtitle": {
-                    "general": "Pause von {{from}} bis {{until}}",
-                    "specific": "Räume von {{from}} bis {{until}}"
+                    "general": "Räume bis {{until}} ({{duration}} Minuten)",
+                    "specific": "Pause von {{from}} bis {{until}}"
+                },
+                "now": "Jetzt"
+            },
+            "modals": {
+                "suggestionPreferences": {
+                    "title": "Vorschlags-Präferenzen",
+                    "description": "Hier kannst du die Dauer und Gebäude der Raumvorschläge anpassen.",
+                    "duration": "Dauer",
+                    "preferredBuildings": "Bevorzugte Gebäude",
+                    "minutes": "Minuten",
+                    "close": "Schließen"
                 }
             }
         },
         "list": {
-          "appbar": {
-            "title": "Stündlicher Raumplan"
-          }  
+            "appbar": {
+                "title": "Stündlicher Raumplan"
+            }
         },
         "common": {
             "availableFromUntil": "frei ab {{from}}<br />bis {{until}}"

--- a/rogue-thi-app/public/locales/de/rooms.json
+++ b/rogue-thi-app/public/locales/de/rooms.json
@@ -76,7 +76,8 @@
             }
         },
         "common": {
-            "availableFromUntil": "frei ab {{from}}<br />bis {{until}}"
+            "availableFromUntil": "frei ab {{from}}<br />bis {{until}}",
+            "allRooms": "Alle Räume"
         }
     }
 }

--- a/rogue-thi-app/public/locales/de/rooms.json
+++ b/rogue-thi-app/public/locales/de/rooms.json
@@ -76,8 +76,7 @@
             }
         },
         "common": {
-            "availableFromUntil": "frei ab {{from}}<br />bis {{until}}",
-            "allRooms": "Alle Räume"
+            "availableFromUntil": "frei ab {{from}}<br />bis {{until}}"
         }
     }
 }

--- a/rogue-thi-app/public/locales/en/api-translations.json
+++ b/rogue-thi-app/public/locales/en/api-translations.json
@@ -13,7 +13,7 @@
         "lecturerOrganizations": {
             "Fakultät Business School": "Faculty Business School",
             "Fakultät Elektro- und Informationstechnik": "Faculty of Electrical Engineering and Information Technology",
-            "Fakultät Informatik": "Faculty of Informatics",
+            "Fakultät Informatik": "Faculty of Computer Science",
             "Fakultät Maschinenbau": "Faculty of Mechanical Engineering",
             "Fakultät Wirtschaftsingenieurwesen": "Faculty of Industrial Engineering",
             "Institut für Akademische Weiterbildung": "Institute for Academic Continuing Education",

--- a/rogue-thi-app/public/locales/en/common.json
+++ b/rogue-thi-app/public/locales/en/common.json
@@ -67,5 +67,8 @@
     "appbar": {
         "back": "Back",
         "overflow": "More options"
+    },
+    "rooms": {
+        "allRooms": "All rooms"
     }
 }

--- a/rogue-thi-app/public/locales/en/rooms.json
+++ b/rogue-thi-app/public/locales/en/rooms.json
@@ -41,18 +41,32 @@
         },
         "suggestions": {
             "appbar": {
-                "title": "Room Suggestions"
+                "title": "Room Suggestions",
+                "overflow": {
+                    "suggestionPreferences": "Change suggestion preferences"
+                }
             },
             "noSuggestions": "No suggestions available.",
             "noAvailableRooms": "No available rooms found.",
             "gaps": {
                 "header": {
                     "general": "Available Rooms",
-                    "specific": "{{from}} <arrow/> {{until}}"
+                    "specific": "{{from}} <arrow/> {{until}} ({{room}})"
                 },
                 "subtitle": {
-                    "general": "Break from {{from}} to {{until}}",
-                    "specific": "Rooms from {{from}} to {{until}}"
+                    "general": "Rooms until {{until}} ({{duration}} minutes)",
+                    "specific": "Break from {{from}} until {{until}}"
+                },
+                "now": "Now"
+            },
+            "modals": {
+                "suggestionPreferences": {
+                    "title": "Suggestion preferences",
+                    "description": "Here you can adjust the duration and buildings of room suggestions.",
+                    "duration": "Duration",
+                    "preferredBuildings": "Preferred buildings",
+                    "minutes": "minutes",
+                    "close": "Close"
                 }
             }
         },

--- a/rogue-thi-app/public/locales/en/rooms.json
+++ b/rogue-thi-app/public/locales/en/rooms.json
@@ -76,7 +76,8 @@
             }
         },
         "common": {
-            "availableFromUntil": "Available from {{from}}<br />to {{until}}"
+            "availableFromUntil": "Available from {{from}}<br />to {{until}}",
+            "allRooms": "All Rooms"
         }
     }
 }

--- a/rogue-thi-app/public/locales/en/rooms.json
+++ b/rogue-thi-app/public/locales/en/rooms.json
@@ -76,8 +76,7 @@
             }
         },
         "common": {
-            "availableFromUntil": "Available from {{from}}<br />to {{until}}",
-            "allRooms": "All Rooms"
+            "availableFromUntil": "Available from {{from}}<br />to {{until}}"
         }
     }
 }

--- a/rogue-thi-app/styles/RoomsSearch.module.css
+++ b/rogue-thi-app/styles/RoomsSearch.module.css
@@ -63,4 +63,5 @@
 
 .container {
   margin: 10px 0px 15px 0px;
+  flex-wrap: wrap;
 }

--- a/rogue-thi-app/styles/RoomsSearch.module.css
+++ b/rogue-thi-app/styles/RoomsSearch.module.css
@@ -60,3 +60,7 @@
   margin-top: 75px;
   text-align: center;
 }
+
+.container {
+  margin: 10px 0px 15px 0px;
+}

--- a/room-distances/calculate-distances.py
+++ b/room-distances/calculate-distances.py
@@ -50,14 +50,14 @@ def main():
 
     # filter rooms by type where a room type is partly in 'Funktion'
     rooms = [room for room in all_rooms if any([room_type in str(room['properties']['Funktion']) for room_type in ROOM_TYPES])]
-    stairscases = [room for room in all_rooms if any([staircase_type in str(room['properties']['Funktion']) for staircase_type in STAIRCASE_TYPES])]
+    staircases = [room for room in all_rooms if any([staircase_type in str(room['properties']['Funktion']) for staircase_type in STAIRCASE_TYPES])]
 
     # add centers to rooms
     for room in rooms:
         room['center'] = calculate_center(room)
 
     # add centers to staircases
-    for staircase in stairscases:
+    for staircase in staircases:
         staircase['center'] = calculate_center(staircase)
 
     # calculate distances between rooms
@@ -78,14 +78,14 @@ def main():
             elif room['properties']['Gebaeude'] != room2['properties']['Gebaeude']:
                 total_distance = 0
                 # find nearest staircase
-                distance1, nearestStaircase1 = findNearestStaircase(room, stairscases)
+                distance1, nearestStaircase1 = findNearestStaircase(room, staircases)
                 total_distance += distance1
 
                 # add distance inside staircase (naive assumption)
                 total_distance += float(room['properties']['Ebene']) * 5
 
                 # find staircase in other building
-                distance2, nearestStaircase2 = findNearestStaircase(room2, stairscases)
+                distance2, nearestStaircase2 = findNearestStaircase(room2, staircases)
                 total_distance += distance2
 
                 # add distance inside staircase (naive assumption)
@@ -100,7 +100,7 @@ def main():
             elif room['properties']['Ebene'] != room2['properties']['Ebene']:
                 total_distance = 0
                 # find nearest staircase
-                staircase_distance, nearest_staircase = findNearestStaircase(room, stairscases)
+                staircase_distance, nearest_staircase = findNearestStaircase(room, staircases)
                 total_distance += staircase_distance
 
                 # add distance inside staircase (naive assumption)


### PR DESCRIPTION
- show room of gap end again
- translate room functions on suggestions page
- small translation fixes (non-room related)
- typos
- add suggestion preferences modal

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 33830c5</samp>

### Summary
🏢🌐🎛️

<!--
1.  🏢 - This emoji represents the building filter hook and the building preferences feature, as well as the use of the `BUILDINGS` constant.
2.  🌐 - This emoji represents the translation changes and additions, both for the API translations and the rooms feature translations.
3.  🎛️ - This emoji represents the modal dialog and the suggestion preferences feature, as well as the refactoring and improvement of the room suggestions and gap results functions.
-->
This pull request improves the room search and suggestion features in the `rogue-thi-app` by adding a modal dialog to edit the preferences, refactoring the code to use utility functions and hooks, and updating the translations. It also fixes a typo in the `room-distances` script and changes a translation in the `api-translations.json` file.

> _`rooms-utils` grows_
> _suggestions and translations_
> _autumn of refactor_

### Walkthrough
*  Added a modal dialog for the user to change the suggestion preferences for the room search ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-96a1e5ca1a4c4b11e904ac5e7091b3a528cbc7414d170739b53663d248648e20R8-R13), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-96a1e5ca1a4c4b11e904ac5e7091b3a528cbc7414d170739b53663d248648e20L20-R26), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-96a1e5ca1a4c4b11e904ac5e7091b3a528cbc7414d170739b53663d248648e20R35), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-96a1e5ca1a4c4b11e904ac5e7091b3a528cbc7414d170739b53663d248648e20L48-R60), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-96a1e5ca1a4c4b11e904ac5e7091b3a528cbc7414d170739b53663d248648e20L101-R244), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-77b216d2e136b509f8aa884bf80652d935617d86ca210980ba498164faacab8bL44-R47), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-77b216d2e136b509f8aa884bf80652d935617d86ca210980ba498164faacab8bL51-R76), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-7691f254ea1919a39e2b29148e081d73457787a40afcb147bd259bd741bd14a3L44-R47), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-7691f254ea1919a39e2b29148e081d73457787a40afcb147bd259bd741bd14a3L51-R69), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-e06c989b916f1113cecfdf1d747443ddaf359e84ae2e50422ec0428c5be83bf2R63-R66))
*  Added a hook to manage the building preferences in the local storage and provide a setter and a saver function for the preferences ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-60308b7b8033c88ae1c834952a06a1c539193572478d16f7f65e46ca6a1dad14R1-R24), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-96a1e5ca1a4c4b11e904ac5e7091b3a528cbc7414d170739b53663d248648e20R68-R70))
*  Added a function to translate the room function from German to English or vice versa using the `i18n` module ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-cec180dc2d7f04377a0dd9436facdf6de328b7c0c8d969bc701be36842dca60aL2-R13), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-cec180dc2d7f04377a0dd9436facdf6de328b7c0c8d969bc701be36842dca60aR267-R273), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-96a1e5ca1a4c4b11e904ac5e7091b3a528cbc7414d170739b53663d248648e20L20-R26), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-96a1e5ca1a4c4b11e904ac5e7091b3a528cbc7414d170739b53663d248648e20R43), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-96a1e5ca1a4c4b11e904ac5e7091b3a528cbc7414d170739b53663d248648e20L125-R264), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-72cc8c0b524c4002391b67caa6f158579525f1f6f45e5a0d93b4510e2b960560L16-R16))
*  Added a function to return all buildings filtered by Neuburg or Ingolstadt using the timetable ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-cec180dc2d7f04377a0dd9436facdf6de328b7c0c8d969bc701be36842dca60aR218-R230))
*  Modified the `getMajorityRoom` function to use the current week and the first day of the week as the date for the timetable, instead of the current date ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-cec180dc2d7f04377a0dd9436facdf6de328b7c0c8d969bc701be36842dca60aL238-R261))
*  Modified the `getEmptySuggestions` function to use the user's preferred duration and buildings from the local storage, instead of the default duration and the majority room ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-cec180dc2d7f04377a0dd9436facdf6de328b7c0c8d969bc701be36842dca60aL250-R309))
*  Removed the `getTranslatedFunction` function and replaced it with the `getTranslatedRoomFunction` function in `RoomMap.js` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-792530fabbecd04fdc814d15979bcb77c6af8beba521aba75e882a8bb526cbdcL1-R1), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-792530fabbecd04fdc814d15979bcb77c6af8beba521aba75e882a8bb526cbdcL13-R13), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-792530fabbecd04fdc814d15979bcb77c6af8beba521aba75e882a8bb526cbdcL61-L67), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-792530fabbecd04fdc814d15979bcb77c6af8beba521aba75e882a8bb526cbdcL108-R101), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-792530fabbecd04fdc814d15979bcb77c6af8beba521aba75e882a8bb526cbdcL129-R122), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-792530fabbecd04fdc814d15979bcb77c6af8beba521aba75e882a8bb526cbdcL202-R195))
*  Removed the `BUILDINGS` constant and imported it from `rooms-utils.js` in `search.js` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-d06b1edec9959d3ba050cdc15c650095df783c880d863cd9c08de292e6120f04L18-R18), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-d06b1edec9959d3ba050cdc15c650095df783c880d863cd9c08de292e6120f04L27))
*  Corrected the typo in the `staircases` variable name in the `calculate-distances.py` file ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-9d8ff702965445e438d2a1d3a952795cb4084cc3c169ba3965f0be59973efac0L53-R53), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-9d8ff702965445e438d2a1d3a952795cb4084cc3c169ba3965f0be59973efac0L60-R60), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-9d8ff702965445e438d2a1d3a952795cb4084cc3c169ba3965f0be59973efac0L81-R81), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-9d8ff702965445e438d2a1d3a952795cb4084cc3c169ba3965f0be59973efac0L88-R88), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/294/files?diff=unified&w=0#diff-9d8ff702965445e438d2a1d3a952795cb4084cc3c169ba3965f0be59973efac0L103-R103))

