### PR TITLE
Add ExamsCard

### DIFF
--- a/rogue-thi-app/components/SwipeableTabs.js
+++ b/rogue-thi-app/components/SwipeableTabs.js
@@ -1,16 +1,21 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 
 import Nav from 'react-bootstrap/Nav'
 import SwipeableViews from 'react-swipeable-views'
 
 /**
- * A `Tabs`-like component that is swipable on mobile.
+ * A `Tabs`-like component that is swipeable on mobile.
  * @param {string} className Class name to attach to the entire object
  * @param {object} children Array of `SwipeableTab` objects
+ * @param {number} defaultPage Index of the tab to show by default
  */
-export default function SwipeableTabs ({ className, children }) {
-  const [page, setPage] = useState(0)
+export default function SwipeableTabs ({ className, children, defaultPage }) {
+  const [page, setPage] = useState(defaultPage || 0)
+
+  useEffect(() => {
+    setPage(defaultPage || 0)
+  }, [defaultPage])
 
   return (
     <div className={className}>
@@ -31,6 +36,7 @@ export default function SwipeableTabs ({ className, children }) {
 }
 SwipeableTabs.propTypes = {
   className: PropTypes.string,
+  defaultPage: PropTypes.number,
   children: PropTypes.any
 }
 

--- a/rogue-thi-app/components/allCards.js
+++ b/rogue-thi-app/components/allCards.js
@@ -1,6 +1,7 @@
 import BaseCard from './cards/BaseCard'
 import CalendarCard from './cards/CalendarCard'
 import EventsCard from './cards/EventsCard'
+import ExamsCard from './cards/ExamsCard'
 import FoodCard from './cards/FoodCard'
 import InstallPrompt from './cards/InstallPrompt'
 import MobilityCard from './cards/MobilityCard'
@@ -29,6 +30,12 @@ export const ALL_DASHBOARD_CARDS = [
         onHide={() => hidePromptCard('install')}
       />
     )
+  },
+  {
+    key: 'exams',
+    removable: true,
+    default: [PLATFORM_DESKTOP, PLATFORM_MOBILE, USER_STUDENT],
+    card: () => <ExamsCard key="exams" />
   },
   {
     key: 'timetable',

--- a/rogue-thi-app/components/cards/CalendarCard.js
+++ b/rogue-thi-app/components/cards/CalendarCard.js
@@ -26,7 +26,7 @@ export default function CalendarCard () {
       try {
         exams = (await loadExamList())
           .filter(x => !!x.date) // remove exams without a date
-          .map(x => ({ name: `Prüfung ${x.titel}`, begin: x.date }))
+          .map(x => ({ name: `${t('calendar.exam')} ${x.titel}`, begin: x.date }))
       } catch (e) {
         if (e instanceof NoSessionError) {
           router.replace('/login')
@@ -43,7 +43,7 @@ export default function CalendarCard () {
       setMixedCalendar(combined)
     }
     load()
-  }, [router])
+  }, [router, t])
 
   return (
     <BaseCard

--- a/rogue-thi-app/components/cards/ExamsCard.js
+++ b/rogue-thi-app/components/cards/ExamsCard.js
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react'
+import ListGroup from 'react-bootstrap/ListGroup'
+import { useRouter } from 'next/router'
+
+import { USER_STUDENT, useUserKind } from '../../lib/hooks/user-kind'
+import BaseCard from './BaseCard'
+import { faUserGraduate } from '@fortawesome/free-solid-svg-icons'
+import { formatFriendlyRelativeTime } from '../../lib/date-utils'
+import { loadExamList } from '../../lib/backend-utils/calendar-utils'
+import { useTime } from '../../lib/hooks/time-hook'
+
+import { NoSessionError } from '../../lib/backend/thi-session-handler'
+
+/**
+ * Dashboard card for semester and exam dates.
+ */
+export default function ExamsCard () {
+  const router = useRouter()
+  const time = useTime()
+  const [exams, setExams] = useState(null)
+  const userKind = useUserKind()
+
+  useEffect(() => {
+    async function load () {
+      try {
+        let examList = await loadExamList()
+
+        // filter out exams that are already over
+        examList = examList.filter(x => x.date > Date.now())
+
+        // filter out exams that are not more than 30 days in the future
+        examList = examList.filter(x => x.date < Date.now() + 1000 * 60 * 60 * 24 * 30)
+
+        setExams(examList)
+      } catch (e) {
+        if (e instanceof NoSessionError) {
+          router.replace('/login')
+        } else {
+          console.error(e)
+          alert(e)
+        }
+      }
+    }
+
+    if (userKind === USER_STUDENT) {
+      load()
+    }
+  }, [router, userKind])
+
+  // return nothing if there are no exams
+  if (!exams || exams.length === 0) {
+    return null
+  }
+
+  return (
+    <BaseCard
+      icon={faUserGraduate}
+      i18nKey="exams"
+      link="/calendar?focus=exams"
+    >
+      <ListGroup variant="flush">
+        {exams && exams.slice(0, 2).map((x, i) => (
+          <ListGroup.Item key={i}>
+            <div>
+              {x.name}
+            </div>
+            <div className="text-muted">
+              {x.seat}
+              { ' - ' }
+              {formatFriendlyRelativeTime(x.date, time)}
+            </div>
+          </ListGroup.Item>
+        ))}
+      </ListGroup>
+    </BaseCard>
+  )
+}

--- a/rogue-thi-app/pages/calendar.js
+++ b/rogue-thi-app/pages/calendar.js
@@ -75,6 +75,9 @@ export default function Calendar () {
     )
   }
 
+  const { focus } = router.query
+  const page = focus === 'exams' ? 1 : 0
+
   return (
     <AppContainer>
       <AppNavbar title={t('calendar.appbar.title')} />
@@ -105,7 +108,7 @@ export default function Calendar () {
           </Modal.Footer>
         </Modal>
 
-        <SwipeableTabs>
+        <SwipeableTabs defaultPage={page}>
           <SwipeableTab className={styles.tab} title={t('calendar.tabs.semester')}>
             <ListGroup variant="flush">
               {calendar.map((item, idx) =>

--- a/rogue-thi-app/public/locales/de/common.json
+++ b/rogue-thi-app/public/locales/de/common.json
@@ -60,7 +60,8 @@
         "library": "Bibliothek",
         "grades": "Noten & Fächer",
         "personal": "Profil",
-        "lecturers": "Dozenten"
+        "lecturers": "Dozenten",
+        "exams": "Prüfungen"
     },
     "prompts": {
         "close": "Schließen"

--- a/rogue-thi-app/public/locales/de/dashboard.json
+++ b/rogue-thi-app/public/locales/de/dashboard.json
@@ -48,7 +48,11 @@
         "date": {
             "ends": "endet",
             "starts": "beginnt"
-        }
+        },
+        "exam": "Prüfung"
+    },
+    "exams": {
+        "title": "Prüfungen"
     },
     "events": {
         "title": "Veranstaltungen",

--- a/rogue-thi-app/public/locales/en/common.json
+++ b/rogue-thi-app/public/locales/en/common.json
@@ -60,7 +60,8 @@
         "library": "Library",
         "grades": "Grades & Subjects",
         "personal": "Profile",
-        "lecturers": "Lecturers"
+        "lecturers": "Lecturers",
+        "exams": "Exams"
     },
     "prompts": {
         "close": "Close"

--- a/rogue-thi-app/public/locales/en/dashboard.json
+++ b/rogue-thi-app/public/locales/en/dashboard.json
@@ -48,7 +48,11 @@
         "date": {
             "ends": "ends",
             "starts": "starts"
-        }
+        },
+        "exam": "Exam"
+    },
+    "exams": {
+        "title": "Exams"
     },
     "events": {
         "title": "Events",


### PR DESCRIPTION
![image](https://github.com/neuland-ingolstadt/neuland.app/assets/39560569/ac128330-4384-4516-bfd3-ffaa3dd0afcd)

This card is shown by default for students but is only visible if there are exams in the next 30 days. 
If there are not exams, the card is completely hidden. 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9fefd5c</samp>

### Summary
🗓️📝🌐

<!--
1.  🗓️ - This emoji represents the calendar feature and the exam events that are shown in the `CalendarCard` component and the calendar page.
2.  📝 - This emoji represents the exams feature and the new dashboard card that shows upcoming exams for students and teachers.
3.  🌐 - This emoji represents the translation feature and the addition of new keys and values to the German and English translation files.
-->
Added a new feature to show upcoming exams from the `exams` platform on the dashboard and the calendar page. Implemented a new `ExamsCard` component to display the exams on the dashboard, and added a `focus` query parameter to the calendar page to select the default tab. Added translations for the new texts in German and English.

> _The dashboard has a new `ExamsCard`_
> _To show you the tests that are not hard_
> _It uses some hooks_
> _And translation books_
> _And links to the `calendar` with a guard_

### Walkthrough
*  Add a new dashboard card for upcoming exams ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-af4ec176af3bf8a0f9b885f1a9abeda79272eed848468a7375071c713d8304e6R9), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-af4ec176af3bf8a0f9b885f1a9abeda79272eed848468a7375071c713d8304e6R35-R40), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-bf718cc9bdccb5b738584020f42d1e204d73fd4dd68189f16694b350108fdecbR1-R79), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-fb32edcf9c6b453131b259e02d545d2c43b53a2e70850af7b1154800b25b5e9dL51-R56), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-34bd987125c20aa08a7cd7547b3e3f2bcfb581fd07ad4bbad8dcebe742da4acbL51-R56))
  * Import the `ExamsCard` component from `cards` folder in `allCards.js` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-af4ec176af3bf8a0f9b885f1a9abeda79272eed848468a7375071c713d8304e6R9))
  * Register the `exams` object in the `ALL_DASHBOARD_CARDS` array in `allCards.js` with key, removable status, default platforms and user kinds, and card rendering function ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-af4ec176af3bf8a0f9b885f1a9abeda79272eed848468a7375071c713d8304e6R35-R40))
  * Implement the `ExamsCard` component in `cards/ExamsCard.js` using various hooks and modules to fetch, filter, and format the exam data, and render the card layout with a list group and a link to the calendar page ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-bf718cc9bdccb5b738584020f42d1e204d73fd4dd68189f16694b350108fdecbR1-R79))
  * Add the `exam` and `exams` keys and values to the German and English translation files for the `dashboard` namespace to provide the translation for the card title and the exam events prefix ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-fb32edcf9c6b453131b259e02d545d2c43b53a2e70850af7b1154800b25b5e9dL51-R56), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-34bd987125c20aa08a7cd7547b3e3f2bcfb581fd07ad4bbad8dcebe742da4acbL51-R56))
* Add a new tab for exams in the calendar page ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-523cbfe2fd6aeaaadf4887be6f0adfc43dbc03c3a9e078617236fa508098fca7L29-R29), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-0b854772c3dc89a4935981b764d7c85e5e8d0a23e87a952fda38f0d76707341fR78-R80), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-0b854772c3dc89a4935981b764d7c85e5e8d0a23e87a952fda38f0d76707341fL108-R111), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-78074d45bf19cf048805f5e665f5939a10d48ed2a38ffc2c3123d580f4cd4a2dL63-R64), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-ec022af9026981fa46167cdc8ca79c0a398891e72057de40ebdf22884d00e495L63-R64))
  * Use the `t` function to translate the `calendar.exam` key for the name of the exam events in the `CalendarCard` component ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-523cbfe2fd6aeaaadf4887be6f0adfc43dbc03c3a9e078617236fa508098fca7L29-R29))
  * Extract the `focus` query parameter from the `router` object in the `calendar` page and assign the `page` variable to 1 if the `focus` is `exams`, or 0 otherwise ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-0b854772c3dc89a4935981b764d7c85e5e8d0a23e87a952fda38f0d76707341fR78-R80))
  * Pass the `defaultPage` prop to the `SwipeableTabs` component in the `calendar` page with the value of the `page` variable to show the appropriate tab by default based on the `focus` query parameter ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-0b854772c3dc89a4935981b764d7c85e5e8d0a23e87a952fda38f0d76707341fL108-R111))
  * Add the `exams` key and value to the German and English translation files for the `common` namespace to provide the translation for the tab title ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-78074d45bf19cf048805f5e665f5939a10d48ed2a38ffc2c3123d580f4cd4a2dL63-R64), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-ec022af9026981fa46167cdc8ca79c0a398891e72057de40ebdf22884d00e495L63-R64))
* Enable the `SwipeableTabs` component to react to changes in the `defaultPage` prop ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-6a04ff4d4e23225278333eda51a6c83cab2b4b369e9ad1a0632a924f11a990cbL1-R1), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-6a04ff4d4e23225278333eda51a6c83cab2b4b369e9ad1a0632a924f11a990cbL8-R19), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-6a04ff4d4e23225278333eda51a6c83cab2b4b369e9ad1a0632a924f11a990cbR39))
  * Import the `useEffect` hook from React in `SwipeableTabs.js` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-6a04ff4d4e23225278333eda51a6c83cab2b4b369e9ad1a0632a924f11a990cbL1-R1))
  * Add the `defaultPage` prop to the `SwipeableTabs` component to allow the parent component to specify which tab should be shown by default ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-6a04ff4d4e23225278333eda51a6c83cab2b4b369e9ad1a0632a924f11a990cbL8-R19))
  * Add the `defaultPage` prop to the prop types validation of the `SwipeableTabs` component to ensure type safety and documentation ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/306/files?diff=unified&w=0#diff-6a04ff4d4e23225278333eda51a6c83cab2b4b369e9ad1a0632a924f11a990cbR39))

