### PR TITLE
🐛 Fix canisius category and unify settings label

### DIFF
--- a/rogue-thi-app/pages/food.js
+++ b/rogue-thi-app/pages/food.js
@@ -261,7 +261,7 @@ export default function Mensa () {
             {canisiusSalads.length > 0 && (
               <>
                 {canisiusFood.length > 0 && (
-                  <h5 className={styles.kindHeader}>{t('list.titles.meals')}</h5>
+                  <h5 className={styles.kindHeader}>{t('list.titles.salads')}</h5>
                 )}
                 <ListGroup>
                   {canisiusSalads.map((meal, idx) => renderMealEntry(meal, `soup-${idx}`))}

--- a/rogue-thi-app/public/locales/de/personal.json
+++ b/rogue-thi-app/public/locales/de/personal.json
@@ -18,7 +18,7 @@
         "debug": "API Spielwiese",
         "privacy": "Datenschutzerklärung",
         "imprint": "Impressum",
-        "language": "Sprache ändern",
+        "language": "Sprache",
         "login": "Anmelden",
         "logout": "Ausloggen",
         "dashboard": "Dashboard",

--- a/rogue-thi-app/public/locales/en/personal.json
+++ b/rogue-thi-app/public/locales/en/personal.json
@@ -18,7 +18,7 @@
         "debug": "API Playground",
         "privacy": "Privacy Policy",
         "imprint": "Imprint",
-        "language": "Change Language",
+        "language": "Language",
         "login": "Log In",
         "logout": "Log Out",
         "dashboard": "Dashboard",


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d57c892</samp>

### Summary
🥗🌐✏️

<!--
1.  🥗 for the change from "Meals" to "Salads" in the German translation. This emoji represents the topic of the list and the type of food that is shown.
2.  🌐 for the change from "Change Language" to "Language" in both translations. This emoji represents the function of the language switcher and the global aspect of the app.
3.  ✏️ for the change from "Change Language" to "Language" in both translations. This emoji represents the editing or updating of the label text.
-->
This pull request updates some German translations in the `rogue-thi-app` subproject. It changes the header for the salads list in `pages/food.js` and the label for the language switcher in `public/locales/de/personal.json` and `public/locales/en/personal.json`.

> _`Meals` becomes `Salads`_
> _Language switcher simplified_
> _Autumn of changes_

### Walkthrough
*  Simplify the label for the language switcher to "Language" in both German and English translations ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/308/files?diff=unified&w=0#diff-29b5c8f319911ec24e2594c9d8c94dae0f7516dadb4310109e6c3d7fde6b7c3fL21-R21), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/308/files?diff=unified&w=0#diff-3caf1b63d06403b1aac18a7511925bf0c87e2dd87b254bc1526f56af5d6b3b80L21-R21))
* Rename the header for the list of salads from "Meals" to "Salads" in the German translation of `food.js` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/308/files?diff=unified&w=0#diff-117046e42df746436c7380830c35f7afbc81c7b53540aa6b92a5a67c23bcac4eL264-R264))

