### PR TITLE
✏️ fix translation key typo

### DIFF
--- a/rogue-thi-app/pages/food.js
+++ b/rogue-thi-app/pages/food.js
@@ -322,7 +322,7 @@ export default function Mensa () {
 
           <Modal.Body>
             <h5>{t('foodModal.flags.title')}</h5>
-            {showMealDetails?.flags === null && `${t('foodModal.flags.unkown')}`}
+            {showMealDetails?.flags === null && `${t('foodModal.flags.unknown')}`}
             {showMealDetails?.flags?.length === 0 && `${t('foodModal.flags.empty')}`}
             <ul>
               {showMealDetails?.flags?.map(flag => (
@@ -341,7 +341,7 @@ export default function Mensa () {
             </ul>
 
             <h5>{t('foodModal.allergens.title')}</h5>
-            {showMealDetails?.allergens === null && `${t('foodModal.allergens.unkown')}`}
+            {showMealDetails?.allergens === null && `${t('foodModal.allergens.unknown')}`}
             {showMealDetails?.allergens?.length === 0 && `${t('foodModal.flags.empty')}`}
             <ul>
               {showMealDetails?.allergens?.map(key => (
@@ -393,7 +393,7 @@ export default function Mensa () {
                   {formatGram(showMealDetails?.nutrition.salt)}
                 </li>
               </ul>)) || (
-              <p>{t('foodModal.nutrition.unkown.title')}</p>
+              <p>{t('foodModal.nutrition.unknown.title')}</p>
             )}
 
             <h5>{t('foodModal.prices.title')}</h5>

--- a/rogue-thi-app/public/locales/de/food.json
+++ b/rogue-thi-app/public/locales/de/food.json
@@ -31,12 +31,12 @@
         "header": "Erläuterung",
         "flags": {
             "title": "Anmerkungen",
-            "unkown": "Unbekannt",
+            "unknown": "Unbekannt",
             "empty": "Keine Anmerkungen vorhanden."
         },
         "allergens": {
             "title": "Allergene",
-            "unkown": "Unbekannt",
+            "unknown": "Unbekannt",
             "empty": "Keine Allergene vorhanden.",
             "fallback" : "Unbekannt (Das ist schlecht)"
         },
@@ -54,7 +54,7 @@
             "fiber.title": "Ballaststoffe",
             "protein.title": "Eiweiß",
             "salt.title": "Salz",
-            "unkown.title": "Unbekannt."
+            "unknown.title": "Unbekannt."
         },
         "prices": {
             "title": "Preise",

--- a/rogue-thi-app/public/locales/de/mobility.json
+++ b/rogue-thi-app/public/locales/de/mobility.json
@@ -22,7 +22,7 @@
             "train": "Bahn ({{station}})",
             "parking": "Parkplätze",
             "charging": "Ladestationen",
-            "unkown": "Mobilität"
+            "unknown": "Mobilität"
         },
         "details": {
             "charging": {

--- a/rogue-thi-app/public/locales/en/food.json
+++ b/rogue-thi-app/public/locales/en/food.json
@@ -30,12 +30,12 @@
         "header": "Details",
         "flags": {
             "title": "Notes",
-            "unkown": "Unknown",
+            "unknown": "Unknown",
             "empty": "No notes available"
         },
         "allergens": {
             "title": "Allergens",
-            "unkown": "Unknown",
+            "unknown": "Unknown",
             "empty": "No allergens present",
             "fallback": "Unknown (This is bad)"
         },
@@ -53,7 +53,7 @@
             "fiber.title": "Fiber",
             "protein.title": "Protein",
             "salt.title": "Salt",
-            "unkown.title": "Unknown"
+            "unknown.title": "Unknown"
         },
         "prices": {
             "title": "Prices",


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d0a3314</samp>

### Summary
🇩🇪🍽️🐛

<!--
1.  🇩🇪 - This emoji represents the German language and indicates that the changes are related to the German translation of the app.
2. 🍽️ - This emoji represents the food category and indicates that the changes are related to the food module of the app.
3. 🐛 - This emoji represents a bug and indicates that the changes are fixing a spelling error or typo in the code.
-->
This pull request fixes a recurring typo in the localization files for the food and mobility modules. The word `unkown` is replaced with `unknown` in both German and English translations. This improves the accuracy and consistency of the user interface.

> _We are the unknown, the hidden and the lost_
> _We defy the typos that corrupt our code_
> _We rise from the shadows, we correct and we compose_
> _We are the unknown, the masters of the mode_

### Walkthrough
*  Fix typos in the translation of the word 'unknown' in the food modal component and the food.json and mobility.json files ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/311/files?diff=unified&w=0#diff-117046e42df746436c7380830c35f7afbc81c7b53540aa6b92a5a67c23bcac4eL325-R325), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/311/files?diff=unified&w=0#diff-117046e42df746436c7380830c35f7afbc81c7b53540aa6b92a5a67c23bcac4eL344-R344), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/311/files?diff=unified&w=0#diff-117046e42df746436c7380830c35f7afbc81c7b53540aa6b92a5a67c23bcac4eL396-R396), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/311/files?diff=unified&w=0#diff-f5e1d5209bf7df49a56662cbd07b82fe918ca2a6e77423191dd06bf81b9f6af7L34-R39), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/311/files?diff=unified&w=0#diff-f5e1d5209bf7df49a56662cbd07b82fe918ca2a6e77423191dd06bf81b9f6af7L57-R57), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/311/files?diff=unified&w=0#diff-19cfa6ad3760f4b3f45cc4170307b22e4a27d41181dd7bc21e0ee1471c1146afL25-R25), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/311/files?diff=unified&w=0#diff-5b234807610c7f55676b9b4e964d0741d7b4196f631e08e00b5a6df8b6ab1810L33-R38), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/311/files?diff=unified&w=0#diff-5b234807610c7f55676b9b4e964d0741d7b4196f631e08e00b5a6df8b6ab1810L56-R56))

