### PR TITLE
🐛💄 Fix spo weights and rework grade page

### DIFF
--- a/rogue-thi-app/lib/backend-utils/grades-utils.js
+++ b/rogue-thi-app/lib/backend-utils/grades-utils.js
@@ -96,7 +96,8 @@ export async function loadGradeAverage () {
     if (grade && spoName && courseSPOs[spoName]) {
       const spo = courseSPOs[spoName]
       const name = simplifyName(x.titel)
-      const entry = spo.find(y => simplifyName(y.name) === name)
+      const spoEntries = spo.filter(y => simplifyName(y.name) === name)
+      const entry = spoEntries.find(y => !!y.weight) || spoEntries[0]
       const other = average.entries.find(y => y.simpleName === name)
 
       if (other) {

--- a/rogue-thi-app/lib/backend-utils/grades-utils.js
+++ b/rogue-thi-app/lib/backend-utils/grades-utils.js
@@ -1,6 +1,8 @@
 import API from '../backend/authenticated-api'
 import courseSPOs from '../../data/spo-grade-weights.json'
 
+const redactGrades = process.env.NEXT_PUBLIC_REDACT_GRADES === 'true' || false
+
 function simplifyName (x) {
   return x.replace(/\W|und|u\./g, '').toLowerCase()
 }
@@ -20,6 +22,18 @@ async function getGradeList () {
       x.note = 'E'
     }
   })
+
+  /**
+   * Set NEXT_PUBLIC_REDACT_GRADES to true to redact your grades (e.g. for screenshots)
+   */
+  if (redactGrades) {
+    gradeList.forEach(x => {
+      if (parseFloat(x.note)) {
+        x.note = '1.0'
+      }
+    })
+  }
+
   return gradeList
 }
 

--- a/rogue-thi-app/pages/grades.jsx
+++ b/rogue-thi-app/pages/grades.jsx
@@ -107,6 +107,36 @@ export default function Grades () {
     alert(t('grades.alerts.notImplemented'))
   }
 
+  /**
+   * A spoiler component that hides its children until clicked.
+   * @param {Object} props
+   * @param {string} props.className
+   * @param {React.ReactNode} props.children
+   * @returns {React.ReactElement} The spoiler component.
+   */
+  function Spoiler ({ className, children }) {
+    const [show, setShow] = useState(false)
+
+    function getStyle (visible) {
+      return visible ? styles.spoilerVisible : styles.spoilerHidden
+    }
+
+    return (
+      <ListGroup.Item
+        className={`${styles.spoiler} ${className}`}
+        onClick={() => setShow(!show)}
+      >
+        <div className={getStyle(show)}>
+          {children}
+        </div>
+
+        <div className={`${styles.spoilerPlaceholder} ${getStyle(!show)}`}>
+          {t('grades.spoiler.reveal')}
+        </div>
+      </ListGroup.Item>
+    )
+  }
+
   return (
     <AppContainer>
       <AppNavbar title={t('grades.appbar.title')}>
@@ -123,55 +153,60 @@ export default function Grades () {
       <AppBody>
         <ReactPlaceholder type="text" rows={3} ready={!!gradeAverage}>
           {gradeAverage && gradeAverage.entries.length > 0 && (
-            <ListGroup>
+            <>
               <h4 className={styles.heading}>
-                {t('grades.summary.title')}
+              {t('grades.summary.title')}
               </h4>
-
-              <ListGroup.Item className={styles.gradeAverageContainer}>
-                <span className={styles.gradeAverage}>
-                  {gradeAverage.resultMin !== gradeAverage.resultMax && '~'}
-                  {formatNum(gradeAverage.result)}
-                </span>
-                {gradeAverage.resultMin !== gradeAverage.resultMax && (
-                  <span className={styles.gradeAverageDisclaimer}>
-                    {t('grades.summary.disclaimer', {
-                      minAverage: formatNum(gradeAverage.resultMin),
-                      maxAverage: formatNum(gradeAverage.resultMax)
-                    })}
+              <ListGroup>
+                <Spoiler className={styles.gradeAverageContainer}>
+                  <span className={styles.gradeAverage}>
+                    {gradeAverage.resultMin !== gradeAverage.resultMax && '~'}
+                    {formatNum(gradeAverage.result)}
                   </span>
-                )}
-              </ListGroup.Item>
-            </ListGroup>
+
+                  {gradeAverage.resultMin !== gradeAverage.resultMax && (
+                    <span className={styles.gradeAverageDisclaimer}>
+                      {t('grades.summary.disclaimer', {
+                        minAverage: formatNum(gradeAverage.resultMin),
+                        maxAverage: formatNum(gradeAverage.resultMax)
+                      })}
+                    </span>
+                  )}
+                </Spoiler>
+              </ListGroup>
+            </>
           )}
         </ReactPlaceholder>
 
+        <h4 className={styles.heading}>
+          {t('grades.gradesList.title')}
+        </h4>
         <ListGroup>
-          <h4 className={styles.heading}>
-            {t('grades.gradesList.title')}
-          </h4>
-
           <ReactPlaceholder type="text" rows={10} ready={grades}>
             {grades && grades.map((item, idx) =>
               <ListGroup.Item key={idx} className={styles.item}>
                 <div className={styles.left}>
                   {item.titel}<br />
-
-                  <div className={styles.details}>
-                    {t('grades.grade')}: {getLocalizedGrade(item.note)}<br />
+                  <small className={styles.details}>
                     {t('grades.ects')}: {item.ects || t('grades.none')}
-                  </div>
+                  </small>
+                </div>
+
+                <div className={styles.grade}>
+                  {getLocalizedGrade(item.note)}<br />
+                  <small className={styles.details}>
+                    {t('grades.grade')}
+                  </small>
                 </div>
               </ListGroup.Item>
             )}
           </ReactPlaceholder>
         </ListGroup>
 
+        <h4 className={styles.heading}>
+          {t('grades.pendingList.title')}
+        </h4>
         <ListGroup>
-          <h4 className={styles.heading}>
-            {t('grades.pendingList.title')}
-          </h4>
-
           <ReactPlaceholder type="text" rows={10} ready={missingGrades}>
             {missingGrades && missingGrades.map((item, idx) =>
               <ListGroup.Item key={idx} className={styles.item}>
@@ -179,8 +214,10 @@ export default function Grades () {
                   {item.titel} ({item.stg}) <br />
 
                   <div className={styles.details}>
-                    {t('grades.deadline')}: {item.frist || t('grades.none')}<br />
-                    {t('grades.ects')}: {item.ects || t('grades.none')}
+                    <small>
+                      {t('grades.deadline')}: {item.frist || t('grades.none')}<br />
+                      {t('grades.ects')}: {item.ects || t('grades.none')}
+                    </small>
                   </div>
                 </div>
               </ListGroup.Item>

--- a/rogue-thi-app/pages/personal.jsx
+++ b/rogue-thi-app/pages/personal.jsx
@@ -29,7 +29,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { FoodFilterContext, ShowDashboardModal, ShowLanguageModal, ShowPersonalDataModal, ShowThemeModal, ThemeContext } from './_app'
 import { NoSessionError, UnavailableSessionError, forgetSession } from '../lib/backend/thi-session-handler'
 import { USER_EMPLOYEE, USER_GUEST, USER_STUDENT, useUserKind } from '../lib/hooks/user-kind'
-import { calculateECTS, loadGradeAverage, loadGrades } from '../lib/backend-utils/grades-utils'
+import { calculateECTS, loadGrades } from '../lib/backend-utils/grades-utils'
 import API from '../lib/backend/authenticated-api'
 
 import styles from '../styles/Personal.module.css'
@@ -42,7 +42,6 @@ const PRIVACY_URL = process.env.NEXT_PUBLIC_PRIVACY_URL
 
 export default function Personal () {
   const [userdata, setUserdata] = useState(null)
-  const [average, setAverage] = useState(null)
   const [ects, setEcts] = useState(null)
   const [grades, setGrades] = useState(null)
   const [missingGrades, setMissingGrades] = useState(null)
@@ -95,9 +94,6 @@ export default function Personal () {
         const data = response.persdata
         data.pcounter = response.pcounter
         setUserdata(data)
-
-        const average = await loadGradeAverage()
-        setAverage(average)
 
         const { finished, missing } = await loadGrades()
         setGrades(finished)
@@ -164,10 +160,6 @@ export default function Personal () {
               </div>
               <span className="text-muted">
                 {ects !== null && `${ects} ${t('personal.overview.ects')} `}
-                {!isNaN(average?.result) && ' · '}
-                {!isNaN(average?.result) && '∅ ' + average.result.toFixed(2).toString().replace('.', ',')}
-                {average?.missingWeight === 1 && ` (${average.missingWeight} ${t('personal.grades.missingWeightSingle')})`}
-                {average?.missingWeight > 1 && ` (${average.missingWeight} ${t('personal.grades.missingWeightMultiple')})`}
               </span>
             </ListGroup.Item>
           </ListGroup>
@@ -225,18 +217,28 @@ export default function Personal () {
 
       <ListGroup>
 
-        <ListGroup.Item action
-          onClick={() => window.open('https://www3.primuss.de/cgi-bin/login/index.pl?FH=fhin', '_blank')}>
+        <ListGroup.Item
+          action
+          className={styles.interaction_row}
+          onClick={() => window.open('https://www3.primuss.de/cgi-bin/login/index.pl?FH=fhin', '_blank')}
+        >
           <FontAwesomeIcon icon={faExternalLink} className={styles.interaction_icon} />
           Primuss
         </ListGroup.Item>
 
-        <ListGroup.Item action onClick={() => window.open('https://moodle.thi.de/moodle', '_blank')}>
+        <ListGroup.Item
+          action
+          className={styles.interaction_row} onClick={() => window.open('https://moodle.thi.de/moodle', '_blank')}
+        >
           <FontAwesomeIcon icon={faExternalLink} className={styles.interaction_icon} />
           Moodle
         </ListGroup.Item>
 
-        <ListGroup.Item action onClick={() => window.open('https://outlook.thi.de/', '_blank')}>
+        <ListGroup.Item
+          action
+          className={styles.interaction_row}
+          onClick={() => window.open('https://outlook.thi.de/', '_blank')}
+        >
           <FontAwesomeIcon icon={faExternalLink} className={styles.interaction_icon} />
           E-Mail
         </ListGroup.Item>
@@ -254,18 +256,30 @@ export default function Personal () {
       <ListGroup>
 
         {showDebug && (
-          <ListGroup.Item action onClick={() => router.push('/debug')}>
+          <ListGroup.Item
+            action
+            className={styles.interaction_row}
+            onClick={() => router.push('/debug')}
+          >
             <FontAwesomeIcon icon={faBug} className={styles.interaction_icon} />
             {t('personal.debug')}
           </ListGroup.Item>
         )}
 
-        <ListGroup.Item action onClick={() => window.open(PRIVACY_URL, '_blank')}>
+        <ListGroup.Item
+          action
+          className={styles.interaction_row}
+          onClick={() => window.open(PRIVACY_URL, '_blank')}
+        >
           <FontAwesomeIcon icon={faShield} className={styles.interaction_icon} />
           {t('personal.privacy')}
         </ListGroup.Item>
 
-        <ListGroup.Item action onClick={() => router.push('/imprint')}>
+        <ListGroup.Item
+          action
+          className={styles.interaction_row}
+          onClick={() => router.push('/imprint')}
+        >
           <FontAwesomeIcon icon={faGavel} className={styles.interaction_icon} />
           {t('personal.imprint')}
         </ListGroup.Item>

--- a/rogue-thi-app/public/locales/de/grades.json
+++ b/rogue-thi-app/public/locales/de/grades.json
@@ -16,6 +16,9 @@
             "title": "Notenschnitt",
             "disclaimer": "Der genaue Notenschnitt kann nicht ermittelt werden und liegt zwischen {{minAverage} und {{maxAverage}}"
         },
+        "spoiler": {
+            "reveal": "Klicken um anzuzeigen"
+        },
         "gradesList": {
             "title": "Noten"
         },

--- a/rogue-thi-app/public/locales/de/personal.json
+++ b/rogue-thi-app/public/locales/de/personal.json
@@ -1,11 +1,6 @@
 {
     "personal": {
         "title": "Profil",
-        "grades": {
-            "title": "Noten",
-            "missingWeightSingle": " Gewichtung fehlt",
-            "missingWeightMultiple": " Gewichtungen fehlen"
-        },
         "overview": {
             "grades": "Noten",
             "ects": "ECTS",

--- a/rogue-thi-app/public/locales/en/grades.json
+++ b/rogue-thi-app/public/locales/en/grades.json
@@ -16,6 +16,9 @@
             "title": "Grade Average",
             "disclaimer": "The exact grade average cannot be determined and ranges between {{minAverage}} and {{maxAverage}}"
         },
+        "spoiler": {
+            "reveal": "Click to reveal"
+        },
         "gradesList": {
             "title": "Grades"
         },

--- a/rogue-thi-app/public/locales/en/personal.json
+++ b/rogue-thi-app/public/locales/en/personal.json
@@ -1,11 +1,6 @@
 {
     "personal": {
         "title": "Profile",
-        "grades": {
-            "title": "Grades",
-            "missingWeightSingle": " weight missing",
-            "missingWeightMultiple": " weights missing"
-        },
         "overview": {
             "grades": "grades",
             "ects": "ECTS",

--- a/rogue-thi-app/styles/Grades.module.css
+++ b/rogue-thi-app/styles/Grades.module.css
@@ -11,11 +11,17 @@
 }
 
 .details {
-  color: gray;
+  color: var(--gray);
+}
+
+.grade {
+  margin-left: 5px;
+  text-align: center;
+  align-self: center;
 }
 
 .right {
-  color: gray;
+  color: var(--gray);
   text-align: right;
 }
 
@@ -23,19 +29,51 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  padding: 15px 20px;
 }
+
 .gradeAverage {
   font-weight: bold;
   font-size: 3rem;
   float: left;
   margin-right: 20px;
+  padding-bottom: 5px;
 }
+
 .gradeAverageDisclaimer {
-  color: gray;
+  color: var(--gray);
 }
 
 .spacer {
   display: inline-block;
   min-width: 10px;
   height: 1px;
+}
+
+.spoilerHidden {
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+}
+
+.spoilerVisible {
+  opacity: 1;
+  transition: opacity 0.5s ease-in-out;
+}
+
+.spoilerPlaceholder {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 3px;
+  color: var(--light);
+  font-size: 1rem;
+  font-weight: bold;
+  border: inherit;
+  background-color: color-mix(in srgb, var(--primary), #ffffff00);
+  box-shadow: inset 0 0 25px 0px var(--primary);
 }

--- a/rogue-thi-app/styles/Personal.module.css
+++ b/rogue-thi-app/styles/Personal.module.css
@@ -21,6 +21,13 @@
   float: right;
 }
 
+.interaction_row {
+  display: flex;
+  flex-direction: row-reverse;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .logout_button {
   display: flex;
   justify-content: center;

--- a/spo-parser/combine_jsons.py
+++ b/spo-parser/combine_jsons.py
@@ -1,12 +1,21 @@
 import os
 import json
+import re
+
+simplifyName = re.compile(r'\W|und|u\./g')
+def simplify(name):
+	return simplifyName.sub("", name).lower()
 
 result = {}
 
 for filename in os.listdir("./weightings/"):
 	name = filename.replace(".json", "")
 	with open("./weightings/" + filename) as fd:
-		result[name] = json.load(fd)
+		content = json.load(fd)
+		for entry in content:
+			entry["name"] = simplify(entry["name"])
+
+		result[name] = content
 
 ects_sums = []
 for name in result:
@@ -21,5 +30,5 @@ ects_sums.sort(key=lambda x: x[1])
 for name, ects in ects_sums:
 	print("{:3d} {}".format(ects, name))
 
-with open("spo-grade-weights.json", "w+") as fd:
-	json.dump(result, fd)
+with open("spo-grade-weights.json", "w+", encoding="utf-8") as fd:
+	json.dump(result, fd, ensure_ascii=False)


### PR DESCRIPTION
Full `spo-grade-weights.json` for testing:
[spo-grade-weights.zip](https://github.com/neuland-ingolstadt/neuland.app/files/12210165/spo-grade-weights.zip)

| Default | THI Light |
|---------| ---|
|![localhost_3000_grades_(iPhone 12 Pro) (6)](https://github.com/neuland-ingolstadt/neuland.app/assets/39560569/ceff6d18-3649-47e0-919b-986e31789f50)|![localhost_3000_grades_(iPhone 12 Pro) (5)](https://github.com/neuland-ingolstadt/neuland.app/assets/39560569/454a6f10-5bd2-48ec-bd7c-b0bc3c1eb8b6)|

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e3c8dc2</samp>

### Summary
🌐🎓🐛

<!--
1.  🌐 - This emoji represents the changes related to the translation files, as it is a globe with meridians that symbolizes internationalization and localization.
2.  🎓 - This emoji represents the changes related to the grades page, as it is a graduation cap that symbolizes education and academic achievement.
3.  🐛 - This emoji represents the changes related to the bug fix and the code improvement, as it is a bug that symbolizes errors and debugging.
-->
This pull request adds a feature to redact grades for privacy reasons, and fixes a bug in finding the correct SPO data for each course. It also improves the layout and appearance of the grades and personal pages, and updates the translation files and the SPO parser script accordingly. The main changes are in the `grades-utils.js`, `grades.jsx`, and `personal.jsx` files, as well as the `Grades.module.css` and `Personal.module.css` files. The `Spoiler` component is a new element that hides the average grade until the user clicks on it. The `combine_jsons.py` script is modified to simplify and preserve the course names. The `grades.json` and `personal.json` files are updated to add or remove the relevant translation keys.

> _Sing, O Muse, of the skillful coder who changed the app_
> _With many a line of `CSS` and `JSX`, and `t` function calls_
> _Who added the `Spoiler` component, hiding the grades from view_
> _Like Zeus concealed his lightning bolts, or Athena her wisdom_

### Walkthrough
*  Add a feature to redact grades for screenshots or privacy reasons ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-77aecdb16d5fe3dc9ddfbd616569b9f788ca04351742c39c2968b5d0a2c24461R4-R5), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-77aecdb16d5fe3dc9ddfbd616569b9f788ca04351742c39c2968b5d0a2c24461R25-R36), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-fda6209d2f3b2e8984cc551dc13d1f8cdea159be212922c898feb33edb32052fR110-R139), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-fda6209d2f3b2e8984cc551dc13d1f8cdea159be212922c898feb33edb32052fL126-R184), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-9a1ed7734fee3b22d6a6194baf180a3a790c2987d9f78b3989b2f29ef9e8bd58R52-R79), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-fbd5dc445ea1ecbf9a319353421918e8096dd5790cbe41c27c3c54e8823704e8R19-R21), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-2758772cd1ac3464a61c278afbaf5a6d2045e9d129b641fbb6a4e3b0d8a85eb6R19-R21))
  - Use an environment variable `NEXT_PUBLIC_REDACT_GRADES` to enable or disable the feature in `grades-utils.js` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-77aecdb16d5fe3dc9ddfbd616569b9f788ca04351742c39c2968b5d0a2c24461R4-R5))
  - Replace all numeric grades with `1.0` if the feature is enabled in `grades-utils.js` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-77aecdb16d5fe3dc9ddfbd616569b9f788ca04351742c39c2968b5d0a2c24461R25-R36))
  - Create a `Spoiler` component that hides its children until clicked in `grades.jsx` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-fda6209d2f3b2e8984cc551dc13d1f8cdea159be212922c898feb33edb32052fR110-R139))
  - Use the `Spoiler` component to wrap the summary section of the grades page in `grades.jsx` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-fda6209d2f3b2e8984cc551dc13d1f8cdea159be212922c898feb33edb32052fL126-R184))
  - Add CSS classes and transitions to create the visual effect of the spoiler component in `Grades.module.css` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-9a1ed7734fee3b22d6a6194baf180a3a790c2987d9f78b3989b2f29ef9e8bd58R52-R79))
  - Add localized text for the spoiler component in `grades.json` for German and English ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-fbd5dc445ea1ecbf9a319353421918e8096dd5790cbe41c27c3c54e8823704e8R19-R21), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-2758772cd1ac3464a61c278afbaf5a6d2045e9d129b641fbb6a4e3b0d8a85eb6R19-R21))
* Fix a bug that could cause incorrect calculations of the average or missing weightings due to multiple courses with the same name ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-77aecdb16d5fe3dc9ddfbd616569b9f788ca04351742c39c2968b5d0a2c24461L99-R114))
  - Use a filter to find all the courses with the same name and select the one with a defined weight or the first one as a fallback in `grades-utils.js` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-77aecdb16d5fe3dc9ddfbd616569b9f788ca04351742c39c2968b5d0a2c24461L99-R114))
* Improve the visual appearance and readability of the grades and pending lists ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-fda6209d2f3b2e8984cc551dc13d1f8cdea159be212922c898feb33edb32052fL159-R200), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-fda6209d2f3b2e8984cc551dc13d1f8cdea159be212922c898feb33edb32052fL170-R209), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-fda6209d2f3b2e8984cc551dc13d1f8cdea159be212922c898feb33edb32052fL182-R220), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-9a1ed7734fee3b22d6a6194baf180a3a790c2987d9f78b3989b2f29ef9e8bd58L14-R24), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-9a1ed7734fee3b22d6a6194baf180a3a790c2987d9f78b3989b2f29ef9e8bd58L26-R34), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-9a1ed7734fee3b22d6a6194baf180a3a790c2987d9f78b3989b2f29ef9e8bd58L32-R44))
  - Separate the grade from the details and make it more prominent in `grades.jsx` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-fda6209d2f3b2e8984cc551dc13d1f8cdea159be212922c898feb33edb32052fL159-R200))
  - Simplify the heading of the pending list and make the text smaller in `grades.jsx` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-fda6209d2f3b2e8984cc551dc13d1f8cdea159be212922c898feb33edb32052fL170-R209), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-fda6209d2f3b2e8984cc551dc13d1f8cdea159be212922c898feb33edb32052fL182-R220))
  - Use a CSS variable `--gray` for the text color of the details and the disclaimer in `Grades.module.css` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-9a1ed7734fee3b22d6a6194baf180a3a790c2987d9f78b3989b2f29ef9e8bd58L14-R24), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-9a1ed7734fee3b22d6a6194baf180a3a790c2987d9f78b3989b2f29ef9e8bd58L32-R44))
  - Add some padding to the container and the bottom of the average in `Grades.module.css` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-9a1ed7734fee3b22d6a6194baf180a3a790c2987d9f78b3989b2f29ef9e8bd58L26-R34), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-9a1ed7734fee3b22d6a6194baf180a3a790c2987d9f78b3989b2f29ef9e8bd58L32-R44))
* Simplify the interface and remove redundant information from the personal page ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL32-R32), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL45), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL99-L101), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL167-L170), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-29b5c8f319911ec24e2594c9d8c94dae0f7516dadb4310109e6c3d7fde6b7c3fL4-L8), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-3caf1b63d06403b1aac18a7511925bf0c87e2dd87b254bc1526f56af5d6b3b80L4-L8))
  - Remove the unused import, state variable, function call, and JSX elements related to the grade average in `personal.jsx` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL32-R32), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL45), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL99-L101), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL167-L170))
  - Remove the unused translation for the grade average in `personal.json` for German and English ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-29b5c8f319911ec24e2594c9d8c94dae0f7516dadb4310109e6c3d7fde6b7c3fL4-L8), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-3caf1b63d06403b1aac18a7511925bf0c87e2dd87b254bc1526f56af5d6b3b80L4-L8))
* Improve the visual appearance and alignment of the links to external services on the personal page ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL228-R241), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL257-R263), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL263-R282), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-877af97d43d4d57a1fe3f10b578cd641d42544a79c37c09ea0e331e21cd0240bR24-R30))
  - Add a `className` attribute with a value of `styles.interaction_row` to each `ListGroup.Item` component in `personal.jsx` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL228-R241), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL257-R263), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL263-R282))
  - Define a `flex` layout with a row-reverse direction, a space-between justification, and a center alignment for the `interaction_row` class in `Personal.module.css` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-877af97d43d4d57a1fe3f10b578cd641d42544a79c37c09ea0e331e21cd0240bR24-R30))
* Create a helper function to simplify the names of the courses by removing irrelevant characters and words in `combine_jsons.py` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-3c558932d41bde46d7a959f329f8bef6815996fff767fa184138567cf7c6d8d0L3-R8), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-3c558932d41bde46d7a959f329f8bef6815996fff767fa184138567cf7c6d8d0L9-R19))
  - Import the `re` module and define a regular expression `simplifyName` that matches non-alphanumeric characters and some words in `combine_jsons.py` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-3c558932d41bde46d7a959f329f8bef6815996fff767fa184138567cf7c6d8d0L3-R8))
  - Define a function `simplify` that uses the regular expression to remove those characters and words from a given name and convert it to lowercase in `combine_jsons.py` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-3c558932d41bde46d7a959f329f8bef6815996fff767fa184138567cf7c6d8d0L3-R8))
  - Call the `simplify` function on each entry in the JSON content and modify the `name` attribute accordingly in `combine_jsons.py` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-3c558932d41bde46d7a959f329f8bef6815996fff767fa184138567cf7c6d8d0L9-R19))
* Ensure that the output file of the `combine_jsons.py` script preserves the non-ASCII characters in the JSON content ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-3c558932d41bde46d7a959f329f8bef6815996fff767fa184138567cf7c6d8d0L24-R34))
  - Specify the encoding as `utf-8` and the `ensure_ascii` option as `False` for the `open` and `json.dump` functions in `combine_jsons.py` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/319/files?diff=unified&w=0#diff-3c558932d41bde46d7a959f329f8bef6815996fff767fa184138567cf7c6d8d0L24-R34))

