### PR TITLE
🐛 Fix timetable errors during semester break

### DIFF
--- a/rogue-thi-app/components/cards/TimetableCard.jsx
+++ b/rogue-thi-app/components/cards/TimetableCard.jsx
@@ -82,11 +82,13 @@ export default function TimetableCard () {
             )
           }))}
           {(timetable && timetable.length === 0) &&
-              <ListGroup.Item>{t('timetable.text.noLectures')}</ListGroup.Item>
+            <ListGroup.Item>
+              {t('timetable.text.noLectures')}
+            </ListGroup.Item>
           }
           {(timetableError &&
-              <ListGroup.Item>{t('timetable.text.error')}</ListGroup.Item>)
-          }
+            <ListGroup.Item>{t('timetable.text.error')}</ListGroup.Item>
+          )}
         </ListGroup>
       </ReactPlaceholder>
     </BaseCard>

--- a/rogue-thi-app/lib/backend-utils/timetable-utils.js
+++ b/rogue-thi-app/lib/backend-utils/timetable-utils.js
@@ -76,6 +76,15 @@ export function getTimetableGaps (timetable) {
 export async function getFriendlyTimetable (date, detailed) {
   const { timetable } = await API.getTimetable(date, detailed)
 
+  /**
+   * During the semester break, the API returns an null array ('[null]').
+   * To prevent errors for the room suggestions or the timetable view, we return an empty array.
+   */
+  if (timetable.every(x => x === null)) {
+    console.error('API returned null array for timetable!')
+    return []
+  }
+
   return timetable
     .flatMap(day =>
       Object.values(day.hours)


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at de9f748</samp>

### Summary
🎨🐛📝

<!--
1.  🎨 for the formatting improvement, as this is a code style or cosmetic change.
2. 🐛 for the bug fix, as this is a change that fixes an issue or error in the code.
3. 📝 for the error message, as this is a change that adds or updates documentation or comments in the code.
-->
This pull request fixes a bug that caused errors when the timetable API returned null data, and improves the formatting of some JSX code. It affects the files `TimetableCard.jsx` and `timetable-utils.js` in the `rogue-thi-app` module.

> _`timetable` null_
> _bug fix for semester break_
> _format JSX code_

### Walkthrough
* Fix bug when API returns null timetable data ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/320/files?diff=unified&w=0#diff-017e3a6434af0820a1df8559840dfac59e199a554f7b96980e0369f562b304f3R79-R87))
* Improve formatting of JSX elements in conditional rendering blocks ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/320/files?diff=unified&w=0#diff-172b010e4dad205e5cc5e6c52d5e3dac0e0ca4177846946dbb0721a7d39c1c17L85-R91))

