### PR TITLE
💄 improve placeholder on personal page and home cards

### DIFF
--- a/rogue-thi-app/components/cards/FoodCard.jsx
+++ b/rogue-thi-app/components/cards/FoodCard.jsx
@@ -6,8 +6,11 @@ import { faUtensils } from '@fortawesome/free-solid-svg-icons'
 import { Trans, useTranslation } from 'next-i18next'
 import BaseCard from './BaseCard'
 import { FoodFilterContext } from '../../pages/_app'
+import { TextBlock } from 'react-placeholder/lib/placeholders'
 import { formatISODate } from '../../lib/date-utils'
 import { loadFoodEntries } from '../../lib/backend-utils/food-utils'
+
+import styles from '../../styles/Home.module.css'
 
 /**
  * Dashboard card for Mensa and Reimanns food plans.
@@ -87,13 +90,24 @@ export default function FoodCard () {
     load()
   }, [selectedRestaurants, preferencesSelection, allergenSelection, t, i18n])
 
+  const placeholder = (
+    <ListGroup variant='flush' >
+      <ListGroup.Item>
+        <TextBlock rows={2} className={styles.placeholder_3_0}/>
+      </ListGroup.Item>
+      <ListGroup.Item>
+        <TextBlock rows={1} className={styles.placeholder_3_0}/>
+      </ListGroup.Item>
+    </ListGroup>
+  )
+
   return (
     <BaseCard
       icon={faUtensils}
       i18nKey={`food.location.${foodCardTitle}`}
       link="/food"
     >
-      <ReactPlaceholder type="text" rows={5} ready={foodEntries || foodError}>
+      <ReactPlaceholder ready={foodEntries || foodError} customPlaceholder={placeholder}>
         <ListGroup variant="flush">
           {foodEntries && foodEntries.map((x, i) => (
             <ListGroup.Item key={i}>

--- a/rogue-thi-app/components/cards/MobilityCard.jsx
+++ b/rogue-thi-app/components/cards/MobilityCard.jsx
@@ -11,6 +11,7 @@ import {
 
 import {
   RenderMobilityEntry,
+  RenderMobilityEntryPlaceholder,
   getMobilityEntries,
   getMobilityLabel,
   getMobilitySettings
@@ -66,13 +67,23 @@ export default function MobilityCard () {
     load()
   }, [mobilitySettings, time, t])
 
+  const placeholder = (
+    <ListGroup variant="flush">
+      {Array.from({ length: 4 }, (_, i) => (
+        <ListGroup.Item className={styles.mobilityItem} key={i}>
+          <RenderMobilityEntryPlaceholder kind={mobilitySettings?.kind} styles={styles} />
+        </ListGroup.Item>
+      ))}
+    </ListGroup>
+  )
+
   return (
     <BaseCard
       icon={mobilityIcon}
       title={t(mobilityLabel)}
       link="/mobility"
     >
-      <ReactPlaceholder type="text" rows={5} ready={mobility || mobilityError}>
+      <ReactPlaceholder ready={mobility || mobilityError} customPlaceholder={placeholder}>
         <ListGroup variant="flush">
           {mobility && mobility.slice(0, 4).map((entry, i) => <ListGroup.Item key={i} className={styles.mobilityItem}>
             <RenderMobilityEntry kind={mobilitySettings.kind} item={entry} maxLen={MAX_STATION_LENGTH} styles={styles} detailed={false}/>

--- a/rogue-thi-app/components/cards/RoomCard.jsx
+++ b/rogue-thi-app/components/cards/RoomCard.jsx
@@ -10,7 +10,9 @@ import { findSuggestedRooms, getEmptySuggestions, getTranslatedRoomName } from '
 import { formatFriendlyTime, isSameDay } from '../../lib/date-utils'
 import { getFriendlyTimetable, getTimetableGaps } from '../../lib/backend-utils/timetable-utils'
 import { NoSessionError } from '../../lib/backend/thi-session-handler'
+
 import ReactPlaceholder from 'react-placeholder/lib'
+import { TextBlock } from 'react-placeholder/lib/placeholders'
 
 import { USER_STUDENT, useUserKind } from '../../lib/hooks/user-kind'
 import Link from 'next/link'
@@ -70,13 +72,23 @@ export default function RoomCard () {
     }
   }, [router, userKind])
 
+  const placeholder = (
+    <ListGroup variant="flush">
+      {Array.from({ length: 2 }, (_, i) => (
+        <ListGroup.Item key={i}>
+          <TextBlock rows={2} />
+        </ListGroup.Item>
+      ))}
+    </ListGroup>
+  )
+
   return (
     <BaseCard
       icon={faDoorOpen}
       i18nKey="rooms"
       link="/rooms"
     >
-      <ReactPlaceholder type="text" rows={4} ready={filterResults || userKind !== USER_STUDENT}>
+      <ReactPlaceholder ready={filterResults || userKind !== USER_STUDENT} customPlaceholder={placeholder}>
         <ListGroup variant="flush">
           {filterResults && filterResults.slice(0, 2).map((x, i) => {
             return (

--- a/rogue-thi-app/components/cards/TimetableCard.jsx
+++ b/rogue-thi-app/components/cards/TimetableCard.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import ListGroup from 'react-bootstrap/ListGroup'
 import ReactPlaceholder from 'react-placeholder'
+import { TextBlock } from 'react-placeholder/lib/placeholders'
 import { useRouter } from 'next/router'
 
 import { faCalendarMinus } from '@fortawesome/free-solid-svg-icons'
@@ -10,6 +11,8 @@ import { getFriendlyTimetable, getTimetableEntryName } from '../../lib/backend-u
 import BaseCard from './BaseCard'
 import { NoSessionError } from '../../lib/backend/thi-session-handler'
 import { useTranslation } from 'next-i18next'
+
+import styles from '../../styles/Home.module.css'
 
 /**
  * Dashboard card for the timetable.
@@ -42,13 +45,25 @@ export default function TimetableCard () {
     return () => clearInterval(interval)
   }, [])
 
+  const placeholder = (
+    <>
+      <ListGroup variant="flush">
+        {Array.from({ length: 2 }, (_, i) => (
+          <ListGroup.Item key={i}>
+            <TextBlock rows={2} className={styles.placeholder_2_5}/>
+          </ListGroup.Item>
+        ))}
+      </ListGroup>
+    </>
+  )
+
   return (
     <BaseCard
       icon={faCalendarMinus}
       i18nKey="timetable"
       link="/timetable"
     >
-      <ReactPlaceholder type="text" rows={5} ready={timetable || timetableError}>
+      <ReactPlaceholder ready={timetable || timetableError} customPlaceholder={placeholder}>
         <ListGroup variant="flush">
           {(timetable && timetable.slice(0, 2).map((x, i) => {
             const isSoon = (x.startDate > currentTime && new Date(x.startDate) <= new Date(currentTime.getTime() + 30 * 60 * 1000))

--- a/rogue-thi-app/lib/backend-utils/mobility-utils.jsx
+++ b/rogue-thi-app/lib/backend-utils/mobility-utils.jsx
@@ -2,6 +2,8 @@ import { faEuroSign, faKey } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCreativeCommonsNcEu } from '@fortawesome/free-brands-svg-icons'
 
+import { TextBlock } from 'react-placeholder/lib/placeholders'
+
 import { formatFriendlyTime, formatRelativeMinutes } from '../date-utils'
 import API from '../backend/authenticated-api'
 import NeulandAPI from '../backend/neuland-api'
@@ -108,6 +110,29 @@ export async function getMobilityEntries (kind, station) {
   }
 }
 
+export function RenderMobilityEntryPlaceholder ({ kind, styles }) {
+  if (kind === 'charging') {
+    return (
+      <>
+        <div className={`${styles.mobilityDestination} ${styles.placeholder_4_0}`}>
+          <TextBlock rows={1} />
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <div className={styles.mobilityRoute}>
+      - - -
+      </div>
+      <div className={styles.mobilityDestination}>
+        <TextBlock rows={1} />
+      </div>
+    </>
+  )
+}
+
 /**
  * Renders a row on the mobility page.
  * @param {string} kind Mobility type (`bus`, `train`, `parking` or `charging`)
@@ -138,17 +163,17 @@ export function RenderMobilityEntry ({ kind, item, maxLen, styles, detailed }) {
     const timeString = formatTimes(item.actualTime, 30, 90)
 
     return (
-  <>
-    <div className={styles.mobilityRoute}>
-      {item.name}
-    </div>
-    <div className={`${styles.mobilityDestination} ${item.canceled ? styles.mobilityCanceled : ''}`}>
-      {item.destination.length <= maxLen ? item.destination : item.destination.substr(0, maxLen) + '…'}
-    </div>
-    <div className={`${styles.mobilityTime} ${item.canceled ? styles.mobilityCanceled : ''}`}>
-      {timeString}
-    </div>
-  </>
+      <>
+        <div className={styles.mobilityRoute}>
+          {item.name}
+        </div>
+        <div className={`${styles.mobilityDestination} ${item.canceled ? styles.mobilityCanceled : ''}`}>
+          {item.destination.length <= maxLen ? item.destination : item.destination.substr(0, maxLen) + '…'}
+        </div>
+        <div className={`${styles.mobilityTime} ${item.canceled ? styles.mobilityCanceled : ''}`}>
+          {timeString}
+        </div>
+      </>
     )
   } else if (kind === 'parking') {
     return (

--- a/rogue-thi-app/package-lock.json
+++ b/rogue-thi-app/package-lock.json
@@ -1263,9 +1263,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001446",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001446.tgz",
-      "integrity": "sha512-fEoga4PrImGcwUUGEol/PoFCSBnSkA9drgdkxXkJLsUBOnJ8rs3zDv6ApqYXGQFOyMPsjh79naWhF4DAxbF8rw==",
+      "version": "1.0.30001543",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001543.tgz",
+      "integrity": "sha512-qxdO8KPWPQ+Zk6bvNpPeQIOH47qZSYdFZd6dXQzb2KzhnSXju4Kd7H1PkSJx6NICSMgo/IhRZRhhfPTHYpJUCA==",
       "funding": [
         {
           "type": "opencollective",
@@ -1274,6 +1274,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },

--- a/rogue-thi-app/pages/personal.jsx
+++ b/rogue-thi-app/pages/personal.jsx
@@ -37,6 +37,7 @@ import themes from '../data/themes.json'
 
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useTranslation } from 'next-i18next'
+import { TextBlock } from 'react-placeholder/lib/placeholders'
 
 const PRIVACY_URL = process.env.NEXT_PUBLIC_PRIVACY_URL
 
@@ -121,11 +122,25 @@ export default function Personal () {
     }
   }, [router, userKind])
 
+  const placeholder = (
+    <>
+      <ListGroup.Item action>
+        <TextBlock rows={2} className={styles.placeholder} />
+      </ListGroup.Item>
+      <ListGroup.Item action>
+        <TextBlock rows={2} className={styles.placeholder} />
+      </ListGroup.Item>
+      <ListGroup.Item action>
+        <TextBlock rows={1} className={styles.placeholder} />
+      </ListGroup.Item>
+    </>
+  )
+
   return (<AppContainer>
     <AppNavbar title={t('personal.title')} />
 
     <AppBody>
-      <ReactPlaceholder type="text" rows={10} ready={userdata || userKind !== USER_STUDENT}>
+      <ReactPlaceholder ready={userdata || userKind !== USER_STUDENT} customPlaceholder={placeholder}>
 
         {userKind === USER_STUDENT &&
           <ListGroup>

--- a/rogue-thi-app/styles/Home.module.css
+++ b/rogue-thi-app/styles/Home.module.css
@@ -98,3 +98,15 @@
   white-space: nowrap;
   width: auto;
 }
+
+.placeholder_2_5 {
+  margin: 2.5px 0;
+}
+
+.placeholder_3_0 {
+  margin: 3px 0;
+}
+
+.placeholder_4_0 {
+  margin: 4px 0;
+}

--- a/rogue-thi-app/styles/Personal.module.css
+++ b/rogue-thi-app/styles/Personal.module.css
@@ -33,3 +33,7 @@
   justify-content: center;
   align-items: center;
 }
+
+.placeholder {
+  margin: 3.5px 0;
+}


### PR DESCRIPTION
Examples:

| Old | New |
|--|--|
|![dev neuland app_personal_(iPhone 12 Pro)](https://github.com/neuland-ingolstadt/neuland.app/assets/39560569/c567d7b8-87ab-45c4-be95-a6b4d7c4f778)|![localhost_3000_personal_(iPhone 12 Pro) (3)](https://github.com/neuland-ingolstadt/neuland.app/assets/39560569/a43af333-21b7-48dc-9efd-7b3afbb96de9)|

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 75642a4</samp>

### Summary
🎨🚀🌐

<!--
1.  🎨 This emoji represents the improvement of the appearance and style of the placeholders and the cards. It can also be used for any design or UI changes.
2.  🚀 This emoji represents the improvement of the user experience and the performance of the app. It can also be used for any features or enhancements that make the app faster or more responsive.
3.  🌐 This emoji represents the improvement of the browser compatibility and the funding information of the app. It can also be used for any changes related to internationalization, localization, or accessibility.
-->
This pull request adds custom placeholders for various components of the neuland.app using `react-placeholder` and CSS modules. This improves the user experience and the visual consistency of the app while the data is loading. The pull request also updates a dependency and adds funding information.

> _Sing, O Muse, of the skillful coder who devised_
> _Custom placeholders for the cards of food and room,_
> _Of mobility and timetable, with `TextBlock` styled_
> _By `Home.module.css` and `Personal.module.css` in bloom._

### Walkthrough
*  Import `TextBlock` component from `react-placeholder` to create custom placeholders for different cards and pages ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-fb07600e575be631efab929c461c2f476f23ce258284ee45b1eeab9e690a2efeL9-R14), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-8569daf0e1f1779e84036030a9fb5be64bbf8d5fad93596a856fc4ea9fb06a4eL13-R15), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-172b010e4dad205e5cc5e6c52d5e3dac0e0ca4177846946dbb0721a7d39c1c17R4), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-3d847139f09982f6ee618bd790a01342ed530c77392124e448804f75f61872ddR5-R6), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbR40))
* Define `placeholder` variables as JSX elements that contain list group items with text blocks of different sizes and margins to mimic the data entries for food, room, timetable, and personal cards and pages ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-fb07600e575be631efab929c461c2f476f23ce258284ee45b1eeab9e690a2efeR93-R103), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-8569daf0e1f1779e84036030a9fb5be64bbf8d5fad93596a856fc4ea9fb06a4eR75-R84), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-172b010e4dad205e5cc5e6c52d5e3dac0e0ca4177846946dbb0721a7d39c1c17R48-R59), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL124-R143))
* Modify `ReactPlaceholder` components to use the `customPlaceholder` prop and pass the `placeholder` variables as the value instead of using the `type` and `rows` props ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-fb07600e575be631efab929c461c2f476f23ce258284ee45b1eeab9e690a2efeL96-R110), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-8569daf0e1f1779e84036030a9fb5be64bbf8d5fad93596a856fc4ea9fb06a4eL79-R91), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-172b010e4dad205e5cc5e6c52d5e3dac0e0ca4177846946dbb0721a7d39c1c17L51-R66), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-363324faffb55f18c2c5cf1f37439d353cc8aa3de8adedd426b84f94709d33fbL124-R143))
* Import `RenderMobilityEntryPlaceholder` function from `mobility-utils` to create custom placeholders for the mobility card ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-a2a5a8c6cf8dd57e6e347a7fcc60ec9c580c9cda48802e21522d90bc97e02bf1R14))
* Define `placeholder` variable as JSX element that contains list group items with mobility entry placeholders of different kinds depending on the mobility settings ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-a2a5a8c6cf8dd57e6e347a7fcc60ec9c580c9cda48802e21522d90bc97e02bf1R70-R79))
* Modify `ReactPlaceholder` component to use the `customPlaceholder` prop and pass the `placeholder` variable as the value instead of using the `type` and `rows` props ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-a2a5a8c6cf8dd57e6e347a7fcc60ec9c580c9cda48802e21522d90bc97e02bf1L75-R86))
* Define `RenderMobilityEntryPlaceholder` function as a component that returns a text block or a dashed line depending on the kind of mobility entry ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-3d847139f09982f6ee618bd790a01342ed530c77392124e448804f75f61872ddR113-R135))
* Modify `RenderMobilityEntry` function to use the `styles` prop to apply custom margins to the mobility destination and time elements ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-3d847139f09982f6ee618bd790a01342ed530c77392124e448804f75f61872ddL141-R176))
* Import `styles` variable from `Home.module.css` to apply custom margins to the text blocks in the timetable card ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-172b010e4dad205e5cc5e6c52d5e3dac0e0ca4177846946dbb0721a7d39c1c17R15-R16))
* Define `.placeholder_2_5`, `.placeholder_3_0`, and `.placeholder_4_0` classes in `Home.module.css` to apply custom margins of 2.5px, 3px, and 4px respectively to the text blocks ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-c5d1f8999f4a8ca777bb4ea0eafd9c2f95c17b7a4e0f8cde153f2790c312e5f8R101-R112))
* Define `.placeholder` class in `Personal.module.css` to apply a custom margin of 3.5px to the text blocks ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-877af97d43d4d57a1fe3f10b578cd641d42544a79c37c09ea0e331e21cd0240bR36-R39))
* Update `caniuse-lite` dependency to the latest version and add `github` funding type and url in `package-lock.json` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-c6d8d9df63eef2d8d65c660dacaa96c623964f69b733daa373a0704f766002a6L1266-R1268), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/328/files?diff=unified&w=0#diff-c6d8d9df63eef2d8d65c660dacaa96c623964f69b733daa373a0704f766002a6R1277-R1280))

 