### PR TITLE
🥅 show THI backend error

### DIFF
--- a/rogue-thi-app/pages/login.jsx
+++ b/rogue-thi-app/pages/login.jsx
@@ -23,6 +23,10 @@ const PRIVACY_URL = process.env.NEXT_PUBLIC_PRIVACY_URL
 const GIT_URL = process.env.NEXT_PUBLIC_GIT_URL
 const GUEST_ONLY = !!process.env.NEXT_PUBLIC_GUEST_ONLY
 
+const KNOWN_BACKEND_ERRORS = [
+  'Response is not valid JSON'
+]
+
 export default function Login () {
   const router = useRouter()
   const { redirect } = router.query
@@ -56,7 +60,12 @@ export default function Login () {
       if (e.message.includes(ORIGINAL_ERROR_WRONG_CREDENTIALS)) {
         setFailure(t('error.wrongCredentials'))
       } else {
-        setFailure(t('error.generic'))
+        console.error(e)
+        if (KNOWN_BACKEND_ERRORS.some(error => e.message.includes(error))) {
+          setFailure(t('error.backend'))
+        } else {
+          setFailure(t('error.generic'))
+        }
       }
     }
   }

--- a/rogue-thi-app/public/locales/de/login.json
+++ b/rogue-thi-app/public/locales/de/login.json
@@ -1,7 +1,8 @@
 {
     "error": {
         "wrongCredentials": "Deine Zugangsdaten sind falsch.",
-        "generic": "Bei der Verbindung zum Server ist ein Fehler aufgetreten."
+        "generic": "Bei der Verbindung zum Server ist ein Fehler aufgetreten.",
+        "backend": "Das THI Backend ist derzeit nicht erreichbar. Bitte versuche es später erneut."
     },
     "alert": "Für diese Funktion musst du eingeloggt sein.",
     "guestOnly": {

--- a/rogue-thi-app/public/locales/en/login.json
+++ b/rogue-thi-app/public/locales/en/login.json
@@ -1,7 +1,8 @@
 {
     "error": {
         "wrongCredentials": "Your login credentials are incorrect.",
-        "generic": "An error occurred while connecting to the server."
+        "generic": "An error occurred while connecting to the server.",
+        "backend": "The THI backend is currently unavailable. Please try again later."
     },
     "alert": "You must be logged in to use this feature.",
     "guestOnly": {


### PR DESCRIPTION
![localhost_3000_login_(iPhone 12 Pro) (1)](https://github.com/neuland-ingolstadt/neuland.app/assets/39560569/05e66318-d9fa-4f33-9fb3-0bc90360067e)

For now, simple method to show backend error of THI to show the user that the error does not occur from the part of Neuland.

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0a26563</samp>

### Summary
🌐🐛🚧

<!--
1.  🌐 - This emoji represents the update of the translation files for different languages, which is related to localization and internationalization of the app.
2.  🐛 - This emoji represents the improvement of the error handling and feedback for the login function, which is related to fixing bugs and enhancing the user experience.
3.  🚧 - This emoji represents the addition of a constant array to store known THI backend error messages, which is related to adding new features or functionality to the app.
-->
Improved login error handling and feedback for the rogue-thi-app. Added a new `error.backend` string to the translation files `login.json` for German and English.

> _Oh we are the coders of the sea_
> _And we work on the login screen_
> _We add `error.backend` to the files_
> _So the users know what's wrong when it fails_

### Walkthrough
*  Add constant array `KNOWN_BACKEND_ERRORS` to store error messages from THI backend ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/336/files?diff=unified&w=0#diff-9d2d7db48c1068041162bcea3b332bf9d97d7bdf05b495641132a5dabf52fb83R26-R29))
*  Modify `login` function to catch and log errors during login process ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/336/files?diff=unified&w=0#diff-9d2d7db48c1068041162bcea3b332bf9d97d7bdf05b495641132a5dabf52fb83L59-R68))
   *  Set `failure` state to `error.backend` if error message matches any of the `KNOWN_BACKEND_ERRORS` ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/336/files?diff=unified&w=0#diff-9d2d7db48c1068041162bcea3b332bf9d97d7bdf05b495641132a5dabf52fb83L59-R68))
   *  Set `failure` state to `error.generic` otherwise ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/336/files?diff=unified&w=0#diff-9d2d7db48c1068041162bcea3b332bf9d97d7bdf05b495641132a5dabf52fb83L59-R68))
*  Update German and English translation files to include new string `error.backend` with corresponding message ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/336/files?diff=unified&w=0#diff-536a85fd5d6378ac248f1e956ce57c5c3c0f23445073f59521a7bbeab672161eL4-R5), [link](https://github.com/neuland-ingolstadt/neuland.app/pull/336/files?diff=unified&w=0#diff-506699681355b2e0639e5c86950d265ee750ac29162f3198fcbfbf1c1f0d3235L4-R5))

