### PR TITLE
🐛 fix room suggestions if no rooms are available

### DIFF
--- a/rogue-thi-app/lib/backend-utils/rooms-utils.js
+++ b/rogue-thi-app/lib/backend-utils/rooms-utils.js
@@ -398,7 +398,7 @@ export async function getEmptySuggestions (asGap = false) {
 
   if (asGap) {
     if (rooms.length < 1) {
-      return []
+      return null
     }
 
     return [(

--- a/rogue-thi-app/pages/rooms/suggestions.jsx
+++ b/rogue-thi-app/pages/rooms/suggestions.jsx
@@ -105,7 +105,10 @@ export default function RoomSearch () {
 
     if (deltaTime > suggestionDuration * 60 * 1000) {
       const emptySuggestions = await getEmptySuggestions(true)
-      suggestions.unshift(emptySuggestions[0])
+
+      if (emptySuggestions) {
+        suggestions.unshift(emptySuggestions[0])
+      }
     }
 
     return suggestions


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 99361cf</samp>

### Summary
🚫🛑🗑️

<!--
1.  🚫 - This emoji represents the change of returning null instead of an empty array, which implies a negative or forbidden result when there are no rooms available for a gap suggestion.
2.  🛑 - This emoji represents the change of adding a condition to check if the `emptySuggestions` array is not null before unshifting the first element, which implies a stop or halt action to prevent an error or a crash.
3.  🗑️ - This emoji represents the change of avoiding rendering an empty card in the suggestions page, which implies a deletion or removal of an unnecessary or unwanted element.
-->
Fixed a bug that caused an error and an empty card to appear in the rooms suggestions page when there are no gap suggestions. Modified the `getEmptySuggestions` function in `rooms-utils.js` and the `getSuggestions` function in `suggestions.jsx` to handle the null case.

> _No rooms available_
> _`getEmptySuggestions` returns null_
> _Empty card no more_

### Walkthrough
* Return null instead of empty array when no gap suggestion is possible ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/374/files?diff=unified&w=0#diff-cec180dc2d7f04377a0dd9436facdf6de328b7c0c8d969bc701be36842dca60aL401-R401))
* Handle null case for emptySuggestions in getSuggestions function ([link](https://github.com/neuland-ingolstadt/neuland.app/pull/374/files?diff=unified&w=0#diff-7f068688a42918c63edf81761676b2a3764797043ee70895344d4478481766feL108-R111))

