### PR TITLE
timetableRoomAvailabilityLight (TRA Light)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,6 @@
   ],
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 }

--- a/rogue-thi-app/components/RoomMap.jsx
+++ b/rogue-thi-app/components/RoomMap.jsx
@@ -118,7 +118,6 @@ export default function RoomMap ({ highlight, roomData }) {
         )
       return [room, availability]
     }))
-    // console.log(roomAvailabilityList['G308'])
 
     setRoomAvailabilityList(roomAvailabilityList)
   }

--- a/rogue-thi-app/components/RoomMap.jsx
+++ b/rogue-thi-app/components/RoomMap.jsx
@@ -118,6 +118,7 @@ export default function RoomMap ({ highlight, roomData }) {
         )
       return [room, availability]
     }))
+    // console.log(roomAvailabilityList['G308'])
 
     setRoomAvailabilityList(roomAvailabilityList)
   }

--- a/rogue-thi-app/pages/timetable.jsx
+++ b/rogue-thi-app/pages/timetable.jsx
@@ -198,23 +198,20 @@ export default function Timetable () {
 
   let roomAvailabilityTextCount = 0
   function roomAvailabilityText (room, lessonStart, lessonEnd) {
-    //! Bug: Freitag bei 12:37: Es sollte das selbe wie bei 11:37 anzeigen; nämlich frei ab 12:20 STATT frei bis 13:05
     const availForm = roomAvailabilityList?.[room]?.[0]?.['from']
     const availUntil = roomAvailabilityList?.[room]?.[0]?.['until']
-    console.log(`${availForm.getHours()}:${String(availForm.getMinutes()).padStart(2, '0')}`, `${availUntil.getHours()}:${String(availUntil.getMinutes()).padStart(2, '0')}`, `${lessonStart.getHours()}:${String(lessonStart.getMinutes()).padStart(2, '0')}`)
     if (availForm && availUntil &&
-      lessonStart > new Date() && // nur wenn Info noch relevant ist
-      roomAvailabilityTextCount === 0 // Zeige nur eine Info
+      lessonStart > new Date() && // only if the information is still relevant
+      roomAvailabilityTextCount === 0 // show only one information
     ) {
       roomAvailabilityTextCount++
-      if (availForm > lessonStart) { // Zeige lessonStart als frei ab, anstatt garnichts
+      if (availForm > lessonStart) { // display 'lessonStart' as free instead of nothing
         return ` ${t('timetable.availableFrom')} ${lessonStart.getHours()}:${String(lessonStart.getMinutes()).padStart(2, '0')}`
-      } else if (availForm > new Date()) { // Wird fast immer angezeigt
+      } else if (availForm > new Date()) { // will be returned most of the time
         const date = new Date(availForm)
         return ` ${t('timetable.availableFrom')} ${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`
-      } else { // Wird selten angezeigt: wenn availUntil < lessonStart
+      } else { // will be returned rarely, if: availUntil < lessonStart
         const date = new Date(availUntil)
-        console.log(date)
         return ` ${t('timetable.availableUntil')} ${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`
       }
     } else {

--- a/rogue-thi-app/pages/timetable.jsx
+++ b/rogue-thi-app/pages/timetable.jsx
@@ -192,7 +192,6 @@ export default function Timetable () {
       return [room, availability]
     }))
 
-    console.log(roomAvailabilityList)
     setRoomAvailabilityList(roomAvailabilityList)
   }
 

--- a/rogue-thi-app/pages/timetable.jsx
+++ b/rogue-thi-app/pages/timetable.jsx
@@ -204,14 +204,14 @@ export default function Timetable () {
       roomAvailabilityTextCount === 0 // show only one information
     ) {
       roomAvailabilityTextCount++
-      if (availForm > lessonStart) { // display 'lessonStart' as free instead of nothing
-        return ` ${t('timetable.availableFrom')} ${lessonStart.getHours()}:${String(lessonStart.getMinutes()).padStart(2, '0')}`
-      } else if (availForm > new Date()) { // will be returned most of the time
+      if (availForm > lessonStart) {
+        return ` ${t('timetable.freeAtLectureStart')}`
+      } else if (availForm > new Date()) {
         const date = new Date(availForm)
         return ` ${t('timetable.availableFrom')} ${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`
-      } else if (new Date(availUntil) - -10 * 60 * 1000 === lessonStart - 0) { // 10min offset bug
-        return ` ${t('timetable.availableUntil')} ${lessonStart.getHours()}:${String(lessonStart.getMinutes()).padStart(2, '0')}`
-      } else { // will be returned rarely, if: availUntil < lessonStart
+      } else if ((availUntil === lessonStart) || (new Date(availUntil) - -10 * 60 * 1000 === lessonStart - 0)) { // 10min offset bug
+        return ` ${t('timetable.alreadyAvailable')}`
+      } else {
         const date = new Date(availUntil)
         return ` ${t('timetable.availableUntil')} ${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`
       }

--- a/rogue-thi-app/pages/timetable.jsx
+++ b/rogue-thi-app/pages/timetable.jsx
@@ -199,21 +199,26 @@ export default function Timetable () {
   function roomAvailabilityText (room, lessonStart, lessonEnd) {
     const availForm = roomAvailabilityList?.[room]?.[0]?.['from']
     const availUntil = roomAvailabilityList?.[room]?.[0]?.['until']
+
     if (availForm && availUntil &&
       lessonStart > new Date() && // only if the information is still relevant
       roomAvailabilityTextCount === 0 // show only one information
     ) {
       roomAvailabilityTextCount++
-      if (availForm > lessonStart) {
+      const availFormDate = availForm
+      let availUntilDate = availUntil
+      if (new Date(availUntil) - -10 * 60 * 1000 === lessonStart - 0) { // 10min offset bug fix
+        availUntilDate = new Date(availUntil - -10 * 60 * 1000)
+      }
+
+      if (availFormDate > lessonStart) {
         return ` ${t('timetable.freeAtLectureStart')}`
-      } else if (availForm > new Date()) {
-        const date = new Date(availForm)
-        return ` ${t('timetable.availableFrom')} ${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`
-      } else if ((availUntil === lessonStart) || (new Date(availUntil) - -10 * 60 * 1000 === lessonStart - 0)) { // 10min offset bug
+      } else if (availFormDate > new Date()) {
+        return ` ${t('timetable.availableFrom')} ${formatFriendlyTime(availFormDate)}`
+      } else if (availUntilDate.getTime() === lessonStart.getTime()) {
         return ` ${t('timetable.alreadyAvailable')}`
       } else {
-        const date = new Date(availUntil)
-        return ` ${t('timetable.availableUntil')} ${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`
+        return ` ${t('timetable.availableUntil')} ${formatFriendlyTime(availUntilDate)}`
       }
     } else {
       return ''

--- a/rogue-thi-app/pages/timetable.jsx
+++ b/rogue-thi-app/pages/timetable.jsx
@@ -197,7 +197,7 @@ export default function Timetable () {
   }
 
   let roomAvailabilityTextCount = 0
-  function roomAvailabilityText (room, lessonStart, lessonEnd) { // :)
+  function roomAvailabilityText (room, lessonStart, lessonEnd) {
     let availForm
     let availUntil
     for (let index = 0; index < roomAvailabilityList?.[room].length; index++) {

--- a/rogue-thi-app/pages/timetable.jsx
+++ b/rogue-thi-app/pages/timetable.jsx
@@ -197,7 +197,7 @@ export default function Timetable () {
   }
 
   let roomAvailabilityTextCount = 0
-  function roomAvailabilityText (room, lessonStart, lessonEnd) {
+  function roomAvailabilityText (room, lessonStart, lessonEnd) { // :)
     let availForm
     let availUntil
     for (let index = 0; index < roomAvailabilityList?.[room].length; index++) {

--- a/rogue-thi-app/pages/timetable.jsx
+++ b/rogue-thi-app/pages/timetable.jsx
@@ -210,6 +210,8 @@ export default function Timetable () {
       } else if (availForm > new Date()) { // will be returned most of the time
         const date = new Date(availForm)
         return ` ${t('timetable.availableFrom')} ${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`
+      } else if (new Date(availUntil) - -10 * 60 * 1000 === lessonStart - 0) { // 10min offset bug
+        return ` ${t('timetable.availableUntil')} ${lessonStart.getHours()}:${String(lessonStart.getMinutes()).padStart(2, '0')}`
       } else { // will be returned rarely, if: availUntil < lessonStart
         const date = new Date(availUntil)
         return ` ${t('timetable.availableUntil')} ${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`

--- a/rogue-thi-app/pages/timetable.jsx
+++ b/rogue-thi-app/pages/timetable.jsx
@@ -177,30 +177,21 @@ export default function Timetable () {
     load(week[0])
   }, [router, timetable, focusedEntry, isDetailedData, week, fetchedWeek])
 
-  if (Object.keys(roomAvailabilityList).length === 0) {
+  useEffect(() => {
+    async function loadRoomAvailability () {
+      const roomAvailabilityData = await getRoomAvailability()
+
+      setRoomAvailabilityList(roomAvailabilityData)
+    }
+
     loadRoomAvailability()
-  }
-
-  async function loadRoomAvailability () {
-    const roomAvailabilityData = await getRoomAvailability()
-
-    const roomAvailabilityList = Object.fromEntries(Object.entries(roomAvailabilityData).map(([room, openings]) => {
-      const availability = openings
-      //* this filter would break roomAvailabilityText()
-      // .filter(opening =>
-      //   new Date(opening.until) > new Date()
-      // )
-      return [room, availability]
-    }))
-
-    setRoomAvailabilityList(roomAvailabilityList)
-  }
+  }, [])
 
   let roomAvailabilityTextCount = 0
   function roomAvailabilityText (room, lessonStart, lessonEnd) {
     let availForm
     let availUntil
-    for (let index = 0; index < roomAvailabilityList?.[room].length; index++) {
+    for (let index = 0; index < roomAvailabilityList?.[room]?.length; index++) {
       if (new Date(roomAvailabilityList?.[room]?.[index]?.['until']) - -10 * 60 * 1000 === lessonStart - 0) { // 10min offset bug fix
         availForm = roomAvailabilityList?.[room]?.[0]?.['from']
         availUntil = new Date(roomAvailabilityList?.[room]?.[0]?.['until'] - -10 * 60 * 1000)

--- a/rogue-thi-app/public/locales/de/timetable.json
+++ b/rogue-thi-app/public/locales/de/timetable.json
@@ -74,6 +74,8 @@
             }
         },
         "availableFrom": "Verfügbar ab",
-        "availableUntil": "Verfügbar bis"
+        "availableUntil": "Verfügbar bis",
+        "freeAtLectureStart": "frei ab Vorlesungsbeginn",
+        "alreadyAvailable": "bereits verfügbar"
     }
 }

--- a/rogue-thi-app/public/locales/de/timetable.json
+++ b/rogue-thi-app/public/locales/de/timetable.json
@@ -72,6 +72,8 @@
                     "close": "Schließen"
                 }
             }
-        }
+        },
+        "availableFrom": "Verfügbar ab",
+        "availableUntil": "Verfügbar bis"
     }
 }

--- a/rogue-thi-app/public/locales/en/timetable.json
+++ b/rogue-thi-app/public/locales/en/timetable.json
@@ -72,6 +72,8 @@
                     "close": "Close"
                 }
             }
-        }
+        },
+        "availableFrom": "available from",
+        "availableUntil": "available until"
     }
 }

--- a/rogue-thi-app/public/locales/en/timetable.json
+++ b/rogue-thi-app/public/locales/en/timetable.json
@@ -74,6 +74,8 @@
             }
         },
         "availableFrom": "available from",
-        "availableUntil": "available until"
+        "availableUntil": "available until",
+        "freeAtLectureStart": "free at lecture start",
+        "alreadyAvailable": "already available"
     }
 }


### PR DESCRIPTION
timetableRoomAvailabilityLight displays the room availability for today's rooms in the timetable, showing only the availability for the next lesson.
This approach reduces clutter and overloading in terms of design, by ensuring that only one line is displayed at most.

## Preview

<img width="380" alt="Bildschirmfoto 2023-12-15 um 08 07 01" src="https://github.com/neuland-ingolstadt/neuland.app/assets/65730791/4c985a8f-f5ae-499b-830e-7489376ef6fe">

<img width="380" alt="Bildschirmfoto 2023-12-15 um 08 21 07" src="https://github.com/neuland-ingolstadt/neuland.app/assets/65730791/38c0259e-38dd-44ad-8dfb-edadb57ce605">

<img width="380" alt="Bildschirmfoto 2023-12-15 um 11 21 26" src="https://github.com/neuland-ingolstadt/neuland.app/assets/65730791/80e7aa36-1c80-411b-8e1f-4769e32ebc73">

<img width="380" alt="Bildschirmfoto 2023-12-15 um 11 41 01" src="https://github.com/neuland-ingolstadt/neuland.app/assets/65730791/fa0b0536-29f6-4ff7-97da-37cbf617d1af">

<img width="380" alt="Bildschirmfoto 2023-12-15 um 12 10 49" src="https://github.com/neuland-ingolstadt/neuland.app/assets/65730791/dda26680-5417-42d0-a76a-5c65230114d0">

<img width="380" alt="Bildschirmfoto 2023-12-15 um 12 25 20" src="https://github.com/neuland-ingolstadt/neuland.app/assets/65730791/a631726a-346a-48fb-943f-a605eeeb600f">

<img width="380" alt="Bildschirmfoto 2023-12-15 um 13 10 31" src="https://github.com/neuland-ingolstadt/neuland.app/assets/65730791/67392fc0-08a5-4562-a0e5-094c88880186">

<img width="380" alt="Bildschirmfoto 2023-12-15 um 13 20 23" src="https://github.com/neuland-ingolstadt/neuland.app/assets/65730791/64f6bc33-c878-4035-8800-d71e0a5d579c">


## Bugs
• Lessons which begin at 8:15 display "free at lecture start"
• Some rooms display "free at lecture start" if there is only a 10min time span between two lessons